### PR TITLE
Limit allele combinations

### DIFF
--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -8,12 +8,24 @@ from minos import dependencies, gramtools, utils
 class Error (Exception): pass
 
 class Adjudicator:
-    def __init__(self, outdir, ref_fasta, reads_file, vcf_files, max_read_length=150, read_error_rate=None, overwrite_outdir=False):
+    def __init__(self,
+        outdir,
+        ref_fasta,
+        reads_file,
+        vcf_files,
+        max_read_length=150,
+        read_error_rate=None,
+        overwrite_outdir=False,
+        max_snps_per_cluster=10,
+        max_ref_len=1000,
+    ):
         self.ref_fasta = os.path.abspath(ref_fasta)
         self.reads_file = os.path.abspath(reads_file)
         self.vcf_files = [os.path.abspath(x) for x in vcf_files]
         self.max_read_length = max_read_length
         self.overwrite_outdir = overwrite_outdir
+        self.max_snps_per_cluster = max_snps_per_cluster
+        self.max_ref_len = max_ref_len
 
         self.outdir = os.path.abspath(outdir)
         self.log_file = os.path.join(self.outdir, 'log.txt')
@@ -44,6 +56,8 @@ class Adjudicator:
             self.ref_fasta,
             self.clustered_vcf,
             max_distance_between_variants=1,
+            max_snps_per_cluster=self.max_snps_per_cluster,
+            max_REF_len=self.max_ref_len,
         )
         clusterer.run()
 

--- a/minos/tasks/adjudicate.py
+++ b/minos/tasks/adjudicate.py
@@ -9,6 +9,8 @@ def run(options):
         max_read_length=options.max_read_length,
         read_error_rate=options.read_error_rate,
         overwrite_outdir=options.force,
+        max_snps_per_cluster=options.max_snps_per_cluster,
+        max_ref_len=options.max_ref_len,
     )
     adj.run()
 

--- a/scripts/minos
+++ b/scripts/minos
@@ -29,6 +29,8 @@ subparser_adjudicate = subparsers.add_parser(
 
 subparser_adjudicate.add_argument('--max_read_length', type=int, help='Maximum read length, this is used by gramtools [%(default)s]', default=150, metavar='INT')
 subparser_adjudicate.add_argument('--read_error_rate', type=float, help='Read error rate. If not given, is estimated from quality scores of first 10,000 reads', metavar='FLOAT')
+subparser_adjudicate.add_argument('--max_snps_per_cluster', type=int, help='maximum allowed SNPs in one cluster. If a cluster has more than this, then it is ignored. Use this option in combination with --max_ref_len to prevent clusters with huge numbers of SNPs [%(default)s]', default=10, metavar='INT')
+subparser_adjudicate.add_argument('--max_ref_len', type=int, help='When loading the VCF files, any records with REF longer than this will be ignored [%(default)s]', default=2000)
 subparser_adjudicate.add_argument('--force', action='store_true', help='Replace outdir, if it already exists')
 subparser_adjudicate.add_argument('outdir', help='Name of output directory')
 subparser_adjudicate.add_argument('ref_fasta', help='Reference FASTA filename (must match VCF file(s))')

--- a/scripts/minos
+++ b/scripts/minos
@@ -64,7 +64,7 @@ subparser_cluster_vcfs = subparsers.add_parser(
 )
 
 subparser_cluster_vcfs.add_argument('--max_ref_len', type=int, help='Maximum length in REF column of VCF files. Lines with REF too long will be ignored. Default is no filtering', metavar='INT')
-subparser_cluster_vcfs.add_argument('--max_snps_per_cluster', type=int, help='Maximum allowed SNPs in one cluster. Default is no maximumi', metavar='INT')
+subparser_cluster_vcfs.add_argument('--max_snps_per_cluster', type=int, help='Maximum allowed SNPs in one cluster. Default is no maximum', metavar='INT')
 subparser_cluster_vcfs.add_argument('--max_var_dist', type=int, help='Variants up to this distance apart are merged [%(default)s]', default=1, metavar='INT')
 subparser_cluster_vcfs.add_argument('-o', '--outfile', help='Name of output VCF file (default is stdout)', default='-', metavar='FILENAME')
 subparser_cluster_vcfs.add_argument('ref_fasta', help='FASTA filename of reference genome that matches the VCF file')

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     test_suite='nose.collector',
     tests_require=['nose >= 1.3'],
     install_requires=[
-        'cluster_vcf_records >= 0.0.1',
+        'cluster_vcf_records >= 0.0.2',
         'gramtools',
         'pyfastaq >= 3.14.0',
         'pysam >= 0.12',


### PR DESCRIPTION
Limit number of alleles (with options to change) in each cluster, to stop number of ALTs exploding