### PR TITLE
Gramtools build tweaks

### DIFF
--- a/minos/tests/adjudicator_test.py
+++ b/minos/tests/adjudicator_test.py
@@ -56,7 +56,11 @@ class TestAdjudicator(unittest.TestCase):
             shutil.rmtree(outdir2)
         ref_fasta = os.path.join(data_dir, 'run.ref.fa')
         reads_file = os.path.join(data_dir, 'run.bwa.bam')
-        vcf_files =  [os.path.join(data_dir, x) for x in ['run.calls.1.vcf', 'run.calls.2.vcf']]
+        # When gramtools build dir supplied, the Adjudicator assumes
+        # one clsutered VCF file that matches the gramtools build run.
+        # This is the clustered VCF made by the Adjudicator, so we
+        # use that instead of the list of original VCF files
+        vcf_files = [adj.clustered_vcf]
         adj = adjudicator.Adjudicator(outdir2, ref_fasta, [reads_file], vcf_files, gramtools_build_dir=gramtools_build_dir, clean=False)
         adj.run()
         self.assertTrue(os.path.exists(outdir2))

--- a/scripts/minos
+++ b/scripts/minos
@@ -27,7 +27,7 @@ subparser_adjudicate = subparsers.add_parser(
 )
 
 subparser_adjudicate.add_argument('--reads', action='append', required=True, help='REQUIRED. Reads file. Can be any format compatible with htslib. Use this option more than once for >1 reads files. If splitting (with one of --total_splits,--variants_per_split,--alleles_per_split), must provide one sorted indexed BAM file of reads', metavar='FILENAME')
-subparser_adjudicate.add_argument('--gramtools_build_dir', help='Gramtools build directory corresponding to input VCF file. If used, skips gramtools build stage and uses the provided directory instead', metavar='DIRNAME')
+subparser_adjudicate.add_argument('--gramtools_build_dir', help='Gramtools build directory corresponding to input VCF file. If used, assumes VCF is clustered, skips clustering and gramtools build stages and uses the provided directory instead', metavar='DIRNAME')
 subparser_adjudicate.add_argument('--gramtools_kmer_size', type=int, help='This number is used with gramtools build --kmer-size. Ignored if --gramtools_build_dir used.  [%(default)s]', default=15, metavar='INT')
 subparser_adjudicate.add_argument('--max_read_length', type=int, help='Maximum read length, this is used by gramtools. If not given, estimated by taking longest of first 10,000 reads', metavar='INT')
 subparser_adjudicate.add_argument('--read_error_rate', type=float, help='Read error rate. If not given, is estimated from quality scores of first 10,000 reads', metavar='FLOAT')


### PR DESCRIPTION
Speedup: ff user provides gramtools build dir, then skip clustering the VCf, because it should already have been clustered