### PR TITLE
Speedup bcftools merge

### DIFF
--- a/minos/dependencies.py
+++ b/minos/dependencies.py
@@ -102,7 +102,7 @@ def find_binaries_and_versions(programs=None):
     data = {}
 
     if programs is None:
-        programs = ['bcftools', 'bwa', 'dnadiff', 'gramtools', 'nextflow']
+        programs = ['bwa', 'dnadiff', 'gramtools', 'nextflow']
 
     for program in programs:
         binary = find_binary(program, allow_fail=True)
@@ -130,7 +130,7 @@ def dependencies_report(programs=None):
     lines = ['minos ' + __version__]
 
     if programs is None:
-        programs = ['bcftools', 'bwa', 'dnadiff', 'gramtools', 'nextflow']
+        programs = ['bwa', 'dnadiff', 'gramtools', 'nextflow']
     programs_data = find_binaries_and_versions(programs=programs)
 
     for program in programs:

--- a/minos/multi_sample_pipeline.py
+++ b/minos/multi_sample_pipeline.py
@@ -209,7 +209,6 @@ params.gramtools_max_read_length = 0
 params.gramtools_kmer_size = 0
 params.gramtools_build_threads = 1
 params.final_outdir = ""
-params.bcftools = "bcftools"
 params.testing = false
 params.cluster_small_vars_ram = 2
 params.gramtools_build_small_vars_ram = 12
@@ -436,7 +435,7 @@ process merge_small_vars_vcfs {
         formatter = logging.Formatter('[minos %(asctime)s %(levelname)s] %(message)s', datefmt='%d-%m-%Y %H:%M:%S')
         fh.setFormatter(formatter)
         log.addHandler(fh)
-        dependencies.check_and_report_dependencies(programs=['bcftools', 'nextflow'])
+        dependencies.check_and_report_dependencies(programs=['nextflow'])
 
         self._prepare_nextflow_input_files()
         original_dir = os.getcwd()
@@ -456,11 +455,8 @@ process merge_small_vars_vcfs {
         if self.nextflow_config_file is not None:
             nextflow_command.extend(['-c', self.nextflow_config_file])
 
-        bcftools = dependencies.find_binary('bcftools')
-
         nextflow_command += [
             nextflow_script,
-            '--bcftools', bcftools,
             '--ref_fasta', self.ref_fasta,
             '--data_in_tsv', self.nextflow_input_tsv,
             '--max_alleles_per_cluster', str(self.max_alleles_per_cluster),

--- a/minos/multi_sample_pipeline.py
+++ b/minos/multi_sample_pipeline.py
@@ -30,7 +30,7 @@ class MultiSamplePipeline:
         nf_ram_cluster_small_vars=2,
         nf_ram_gramtools_build_small=12,
         nf_ram_minos_small_vars=5,
-        nf_ram_bcftools_merge=2,
+        nf_ram_merge_small_vars=4,
     ):
         self.ref_fasta = os.path.abspath(ref_fasta)
         if not os.path.exists(self.ref_fasta):
@@ -65,7 +65,7 @@ class MultiSamplePipeline:
         self.nf_ram_cluster_small_vars =  nf_ram_cluster_small_vars
         self.nf_ram_gramtools_build_small = nf_ram_gramtools_build_small
         self.nf_ram_minos_small_vars = nf_ram_minos_small_vars
-        self.nf_ram_bcftools_merge = nf_ram_bcftools_merge
+        self.nf_ram_merge_small_vars = nf_ram_merge_small_vars
 
 
 
@@ -213,7 +213,7 @@ params.testing = false
 params.cluster_small_vars_ram = 2
 params.gramtools_build_small_vars_ram = 12
 params.minos_small_vars_ram = 5
-params.bcftools_merge_ram = 2
+params.merge_small_vars_ram = 4
 params.variants_per_split = 0
 params.alleles_per_split = 0
 params.total_splits = 0
@@ -468,7 +468,7 @@ process merge_small_vars_vcfs {
             '--gramtools_kmer_size', str(self.gramtools_kmer_size),
             '--gramtools_build_threads', str(self.gramtools_build_threads),
             '--minos_small_vars_ram', str(self.nf_ram_minos_small_vars),
-            '--bcftools_merge_ram', str(self.nf_ram_bcftools_merge),
+            '--merge_small_vars_ram', str(self.nf_ram_merge_small_vars),
         ]
 
         if self.testing:

--- a/minos/tasks/multi_sample_pipeline.py
+++ b/minos/tasks/multi_sample_pipeline.py
@@ -21,7 +21,7 @@ def run(options):
         nf_ram_cluster_small_vars=options.nf_ram_cluster_small_vars,
         nf_ram_gramtools_build_small=options.nf_ram_gramtools_build_small,
         nf_ram_minos_small_vars=options.nf_ram_minos_small_vars,
-        nf_ram_bcftools_merge=options.nf_ram_bcftools_merge,
+        nf_ram_merge_small_vars=options.nf_ram_merge_small_vars,
         testing=options.testing,
     )
     pipeline.run()

--- a/minos/tests/data/multi_sample_pipeline/merge_vcf_files.in.1.vcf
+++ b/minos/tests/data/multi_sample_pipeline/merge_vcf_files.in.1.vcf
@@ -1,0 +1,8 @@
+##header1
+##header2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1
+ref1	1	.	G	T	.	PASS	.	.	sample1.row1
+ref1	2	.	C	T	.	PASS	.	.	sample1.row2
+ref1	3	.	T	A	.	PASS	.	.	sample1.row3
+ref1	5	.	AGAGTCACGTA	G	.	PASS	.	.	sample1.row4
+ref2	42	.	C	G	.	PASS	.	.	sample1.row5

--- a/minos/tests/data/multi_sample_pipeline/merge_vcf_files.in.2.vcf
+++ b/minos/tests/data/multi_sample_pipeline/merge_vcf_files.in.2.vcf
@@ -1,0 +1,8 @@
+##header1
+##header2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample2
+ref1	1	.	G	T	.	PASS	.	.	sample2.row1
+ref1	2	.	C	T	.	PASS	.	.	sample2.row2
+ref1	3	.	T	A	.	PASS	.	.	sample2.row3
+ref1	5	.	AGAGTCACGTA	G	.	PASS	.	.	sample2.row4
+ref2	42	.	C	G	.	PASS	.	.	sample2.row5

--- a/minos/tests/data/multi_sample_pipeline/merge_vcf_files.in.3.vcf
+++ b/minos/tests/data/multi_sample_pipeline/merge_vcf_files.in.3.vcf
@@ -1,0 +1,8 @@
+##header1
+##header2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample3
+ref1	1	.	G	T	.	PASS	.	.	sample3.row1
+ref1	2	.	C	T	.	PASS	.	.	sample3.row2
+ref1	3	.	T	A	.	PASS	.	.	sample3.row3
+ref1	5	.	AGAGTCACGTA	G	.	PASS	.	.	sample3.row4
+ref2	42	.	C	G	.	PASS	.	.	sample3.row5

--- a/minos/tests/data/multi_sample_pipeline/merge_vcf_files.out.vcf
+++ b/minos/tests/data/multi_sample_pipeline/merge_vcf_files.out.vcf
@@ -1,0 +1,8 @@
+##header1
+##header2
+#CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2	sample3
+ref1	1	.	G	T	.	PASS	.	.	sample1.row1	sample2.row1	sample3.row1
+ref1	2	.	C	T	.	PASS	.	.	sample1.row2	sample2.row2	sample3.row2
+ref1	3	.	T	A	.	PASS	.	.	sample1.row3	sample2.row3	sample3.row3
+ref1	5	.	AGAGTCACGTA	G	.	PASS	.	.	sample1.row4	sample2.row4	sample3.row4
+ref2	42	.	C	G	.	PASS	.	.	sample1.row5	sample2.row5	sample3.row5

--- a/minos/tests/data/multi_sample_pipeline/run.out.vcf
+++ b/minos/tests/data/multi_sample_pipeline/run.out.vcf
@@ -1,5 +1,4 @@
 ##fileformat=VCFv4.2
-##FILTER=<ID=PASS,Description="All filters passed">
 ##source=minos, version 0.4.1
 ##fileDate=2018-05-18
 ##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
@@ -8,12 +7,9 @@
 ##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">
 ##INFO=<ID=KMER,Number=1,Type=Integer,Description="Kmer size at which variant was discovered (kmer-size used by gramtools build)">
 ##minos_max_read_length=100
-##contig=<ID=ref.0>
-##bcftools_mergeVersion=1.3.1+htslib-1.3.1
-##bcftools_mergeCommand=merge -l vcf_file_list_for_bcftools.txt -o combined_calls.vcf
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample.1	sample.2
-ref.0	75	.	A	G	.	.	KMER=5	GT:DP:COV:GT_CONF	0/0:9:9,0:118.13	1/1:10:0,10:116.09
-ref.0	150	.	G	A,T	.	.	KMER=5	GT:DP:COV:GT_CONF	1/1:17:0,17,0:195.37	2/2:19:0,0,19:198
-ref.0	450	.	T	C	.	.	KMER=5	GT:DP:COV:GT_CONF	1/1:26:0,26:277.8	0/0:24:24,0:241.53
-ref.0	610	.	A	G	.	.	KMER=5	GT:DP:COV:GT_CONF	1/1:31:0,31:335.16	./.:0:0,0:0
-ref.0	800	.	C	CA	.	.	KMER=5	GT:DP:COV:GT_CONF	1/1:22:0,22:252.45	0/0:23:23,0:254.85
+ref.0	75	.	A	G	.	.	KMER=5	DP:GT:COV:GT_CONF	9:0/0:9,0:118.13	10:1/1:0,10:116.09
+ref.0	150	.	G	A,T	.	.	KMER=5	DP:GT:COV:GT_CONF	17:1/1:0,17,0:195.37	19:2/2:0,0,19:198.0
+ref.0	450	.	T	C	.	.	KMER=5	DP:GT:COV:GT_CONF	26:1/1:0,26:277.8	24:0/0:24,0:241.53
+ref.0	610	.	A	G	.	.	KMER=5	DP:GT:COV:GT_CONF	31:1/1:0,31:335.16	0:./.:0,0:0.0
+ref.0	800	.	C	CA	.	.	KMER=5	DP:GT:COV:GT_CONF	22:1/1:0,22:252.45	23:0/0:23,0:254.85

--- a/minos/tests/dependencies_test.py
+++ b/minos/tests/dependencies_test.py
@@ -5,11 +5,6 @@ import unittest
 from minos import dependencies
 
 class TestDependencies(unittest.TestCase):
-    def test_find_binary_bcftools(self):
-        '''test find_binary bcftools'''
-        self.assertIsNotNone(dependencies.find_binary('bcftools'))
-
-
     def test_find_binary_gramtools(self):
         '''test find_binary gramtools'''
         self.assertIsNotNone(dependencies.find_binary('gramtools'))
@@ -18,16 +13,6 @@ class TestDependencies(unittest.TestCase):
     def test_find_binary_bwa(self):
         '''test find_binary bwa'''
         self.assertIsNotNone(dependencies.find_binary('bwa'))
-
-
-    def test_get_version_of_program_bcftools(self):
-        '''test get_version_of_program bcftools'''
-        # We don't know what the version might be, so just
-        # check that we got something that starts with X.Y.Z.
-        got = dependencies.get_version_of_program('bcftools')
-        self.assertIsNotNone(got)
-        version_regex = re.compile(r'^[0-9]+\.[0-9]+\.[0-9]+ ')
-        self.assertIsNotNone(version_regex.search(got))
 
 
     def test_get_version_of_program_gramtools(self):
@@ -85,7 +70,7 @@ class TestDependencies(unittest.TestCase):
         # We don't know what the vetsions will be.
         # Just check we don't get None
         got = dependencies.find_binaries_and_versions()
-        self.assertEqual(['bcftools', 'bwa', 'dnadiff', 'gramtools', 'nextflow'], sorted(list(got.keys())))
+        self.assertEqual(['bwa', 'dnadiff', 'gramtools', 'nextflow'], sorted(list(got.keys())))
         for version, path in got.items():
             self.assertIsNotNone(version)
             self.assertIsNotNone(path)

--- a/minos/tests/multi_sample_pipeline_test.py
+++ b/minos/tests/multi_sample_pipeline_test.py
@@ -59,15 +59,11 @@ class TestMultiSamplePipeline(unittest.TestCase):
 
     def test_merge_vcf_files(self):
         '''test merge_vcf_files'''
-        tmp_fofn = 'tmp.merge_vcf_files.fofn'
-        with open(tmp_fofn, 'w') as f:
-            for i in (1, 2, 3):
-                print(os.path.join(data_dir, 'merge_vcf_files.in.' + str(i) + '.vcf'), file=f)
+        file_list = [os.path.join(data_dir, 'merge_vcf_files.in.' + str(i) + '.vcf') for i in (1, 2, 3)]
         tmp_out = 'tmp.merge_vcf_files.out.vcf'
         expected = os.path.join(data_dir, 'merge_vcf_files.out.vcf')
-        multi_sample_pipeline.MultiSamplePipeline._merge_vcf_files(tmp_fofn, tmp_out)
+        multi_sample_pipeline.MultiSamplePipeline._merge_vcf_files(file_list, tmp_out)
         self.assertTrue(filecmp.cmp(expected, tmp_out, shallow=False))
-        os.unlink(tmp_fofn)
         os.unlink(tmp_out)
 
 

--- a/minos/tests/multi_sample_pipeline_test.py
+++ b/minos/tests/multi_sample_pipeline_test.py
@@ -139,7 +139,7 @@ class TestMultiSamplePipeline(unittest.TestCase):
 
 
     def test_run_no_small_var_vcf_chunking(self):
-        '''test run without chunking small variatn VCF file'''
+        '''test run without chunking small variant VCF file'''
         input_tsv = 'tmp.multi_sample_pipeline.run.in.tsv'
         ref_fasta = os.path.join(data_dir, 'run.ref.0.fa')
         with open(input_tsv, 'w') as f:

--- a/minos/tests/multi_sample_pipeline_test.py
+++ b/minos/tests/multi_sample_pipeline_test.py
@@ -57,6 +57,20 @@ class TestMultiSamplePipeline(unittest.TestCase):
             os.unlink(filename)
 
 
+    def test_merge_vcf_files(self):
+        '''test merge_vcf_files'''
+        tmp_fofn = 'tmp.merge_vcf_files.fofn'
+        with open(tmp_fofn, 'w') as f:
+            for i in (1, 2, 3):
+                print(os.path.join(data_dir, 'merge_vcf_files.in.' + str(i) + '.vcf'), file=f)
+        tmp_out = 'tmp.merge_vcf_files.out.vcf'
+        expected = os.path.join(data_dir, 'merge_vcf_files.out.vcf')
+        multi_sample_pipeline.MultiSamplePipeline._merge_vcf_files(tmp_fofn, tmp_out)
+        self.assertTrue(filecmp.cmp(expected, tmp_out, shallow=False))
+        os.unlink(tmp_fofn)
+        os.unlink(tmp_out)
+
+
     def test_filter_input_file_for_clustering(self):
         infile = os.path.join(data_dir, 'filter_input_file_for_clustering.in.vcf')
         expect = os.path.join(data_dir, 'filter_output_file_for_clusteroutg.out.vcf')

--- a/scripts/minos
+++ b/scripts/minos
@@ -130,7 +130,7 @@ subparser_multi_sample_pipeline.add_argument('--no_clean', action='store_true', 
 subparser_multi_sample_pipeline.add_argument('--nf_ram_cluster_small_vars', type=float, help='Nextflow RAM limit when clustering small variants [%(default)s]', metavar='FLOAT', default=2)
 subparser_multi_sample_pipeline.add_argument('--nf_ram_gramtools_build_small', type=float, help='Nextflow RAM limit when running gramtools build on small variants [%(default)s]', metavar='FLOAT', default=12)
 subparser_multi_sample_pipeline.add_argument('--nf_ram_minos_small_vars', type=float, help='Nextflow RAM limit when running minos on small variants [%(default)s]', metavar='FLOAT', default=5)
-subparser_multi_sample_pipeline.add_argument('--nf_ram_bcftools_merge', type=float, help='Nextflow RAM limit when running vcftools merge [%(default)s]', metavar='FLOAT', default=2)
+subparser_multi_sample_pipeline.add_argument('--nf_ram_merge_small_vars', type=float, help='Nextflow RAM limit when merging small variant vcf files [%(default)s]', metavar='FLOAT', default=2)
 subparser_multi_sample_pipeline.add_argument('--testing', action='store_true', help=argparse.SUPPRESS)
 subparser_multi_sample_pipeline.set_defaults(func=minos.tasks.multi_sample_pipeline.run)
 


### PR DESCRIPTION
Replace bcftools merge with custom python code, because vcftools can't handle large number of files. Instead, load all VCF data into memory, then write final output file 