### PR TITLE
use gramtools build --all-kmers. Default k=10. Use k=5 for tests

### DIFF
--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -21,7 +21,7 @@ class Adjudicator:
         overwrite_outdir=False,
         max_alleles_per_cluster=5000,
         gramtools_build_dir=None,
-        gramtools_kmer_size=15,
+        gramtools_kmer_size=10,
         sample_name=None,
         variants_per_split=None,
         alleles_per_split=None,
@@ -88,7 +88,7 @@ class Adjudicator:
 
             return kmer_size_from_json
         elif input_kmer_size is None:
-            return 15
+            return 10
         else:
             return input_kmer_size
 

--- a/minos/gramtools.py
+++ b/minos/gramtools.py
@@ -28,7 +28,7 @@ def _build_json_file_is_good(json_build_report):
         return returned_zero
 
 
-def run_gramtools_build(outdir, vcf_file, ref_file, max_read_length, kmer_size=15):
+def run_gramtools_build(outdir, vcf_file, ref_file, max_read_length, kmer_size=10):
     '''Runs gramtools build. Makes new directory called 'outdir' for
     the output'''
     gramtools_exe = dependencies.find_binary('gramtools')
@@ -39,6 +39,7 @@ def run_gramtools_build(outdir, vcf_file, ref_file, max_read_length, kmer_size=1
         '--vcf', vcf_file,
         '--reference', ref_file,
         '--max-read-length', str(max_read_length),
+        '--all-kmers',
         '--kmer-size', str(kmer_size),
     ])
     logging.info('Running gramtools build: ' + build_command)
@@ -53,7 +54,7 @@ def run_gramtools_build(outdir, vcf_file, ref_file, max_read_length, kmer_size=1
     logging.info('Build report file looks good from gramtools build: ' + build_report)
 
 
-def run_gramtools(build_dir, quasimap_dir, vcf_file, ref_file, reads, max_read_length, kmer_size=15):
+def run_gramtools(build_dir, quasimap_dir, vcf_file, ref_file, reads, max_read_length, kmer_size=10):
     '''If build_dir does not exist, runs runs gramtools build and quasimap.
     Otherwise, just runs quasimap. quasimap output is in new
     directory called quasimap_dir.

--- a/minos/tests/adjudicator_test.py
+++ b/minos/tests/adjudicator_test.py
@@ -14,7 +14,7 @@ class TestAdjudicator(unittest.TestCase):
         self.assertEqual(42, adjudicator.Adjudicator._get_gramtools_kmer_size(build_dir, None))
         self.assertEqual(42, adjudicator.Adjudicator._get_gramtools_kmer_size(build_dir, 20))
         self.assertEqual(20, adjudicator.Adjudicator._get_gramtools_kmer_size(None, 20))
-        self.assertEqual(15, adjudicator.Adjudicator._get_gramtools_kmer_size(None, None))
+        self.assertEqual(10, adjudicator.Adjudicator._get_gramtools_kmer_size(None, None))
 
 
     def test_run(self):
@@ -29,7 +29,7 @@ class TestAdjudicator(unittest.TestCase):
         ref_fasta = os.path.join(data_dir, 'run.ref.fa')
         reads_file = os.path.join(data_dir, 'run.bwa.bam')
         vcf_files =  [os.path.join(data_dir, x) for x in ['run.calls.1.vcf', 'run.calls.2.vcf']]
-        adj = adjudicator.Adjudicator(outdir, ref_fasta, [reads_file], vcf_files, variants_per_split=3, clean=False)
+        adj = adjudicator.Adjudicator(outdir, ref_fasta, [reads_file], vcf_files, variants_per_split=3, clean=False, gramtools_kmer_size=5)
         adj.run()
         self.assertTrue(os.path.exists(outdir))
         self.assertTrue(os.path.exists(adj.log_file))
@@ -38,7 +38,7 @@ class TestAdjudicator(unittest.TestCase):
 
         # Clean up and then run without splitting
         shutil.rmtree(outdir)
-        adj = adjudicator.Adjudicator(outdir, ref_fasta, [reads_file], vcf_files, clean=False)
+        adj = adjudicator.Adjudicator(outdir, ref_fasta, [reads_file], vcf_files, clean=False, gramtools_kmer_size=5)
         adj.run()
         self.assertTrue(os.path.exists(outdir))
         self.assertTrue(os.path.exists(adj.log_file))
@@ -65,7 +65,7 @@ class TestAdjudicator(unittest.TestCase):
         # This is the clustered VCF made by the Adjudicator, so we
         # use that instead of the list of original VCF files
         vcf_files = [adj.clustered_vcf]
-        adj = adjudicator.Adjudicator(outdir2, ref_fasta, [reads_file], vcf_files, gramtools_build_dir=gramtools_build_dir, clean=False)
+        adj = adjudicator.Adjudicator(outdir2, ref_fasta, [reads_file], vcf_files, gramtools_build_dir=gramtools_build_dir, clean=False, gramtools_kmer_size=5)
         adj.run()
         self.assertTrue(os.path.exists(outdir2))
         self.assertTrue(os.path.exists(adj.log_file))
@@ -91,7 +91,7 @@ class TestAdjudicator(unittest.TestCase):
         ref_fasta = os.path.join(data_dir, 'run.ref.fa')
         reads_file = os.path.join(data_dir, 'run.bwa.bam')
         vcf_files =  [os.path.join(data_dir, x) for x in ['run.calls.empty.1.vcf', 'run.calls.empty.2.vcf']]
-        adj = adjudicator.Adjudicator(outdir, ref_fasta, [reads_file], vcf_files, clean=False)
+        adj = adjudicator.Adjudicator(outdir, ref_fasta, [reads_file], vcf_files, clean=False, gramtools_kmer_size=5)
         with self.assertRaises(adjudicator.Error):
             adj.run()
         self.assertTrue(os.path.exists(outdir))

--- a/minos/tests/gramtools_test.py
+++ b/minos/tests/gramtools_test.py
@@ -32,7 +32,7 @@ class TestGramtools(unittest.TestCase):
             shutil.rmtree(tmp_out_build)
         vcf_file = os.path.join(data_dir, 'run_gramtools.calls.vcf')
         ref_file = os.path.join(data_dir, 'run_gramtools.ref.fa')
-        gramtools.run_gramtools_build(tmp_out_build, vcf_file, ref_file, 150)
+        gramtools.run_gramtools_build(tmp_out_build, vcf_file, ref_file, 150, kmer_size=5)
         self.assertTrue(os.path.exists(tmp_out_build))
         shutil.rmtree(tmp_out_build)
 
@@ -48,7 +48,7 @@ class TestGramtools(unittest.TestCase):
         vcf_file = os.path.join(data_dir, 'run_gramtools.calls.vcf')
         ref_file = os.path.join(data_dir, 'run_gramtools.ref.fa')
         reads_file = os.path.join(data_dir, 'run_gramtools.reads.fq')
-        build_report, quasimap_report = gramtools.run_gramtools(tmp_out_build, tmp_out_quasimap, vcf_file, ref_file, reads_file, 150)
+        build_report, quasimap_report = gramtools.run_gramtools(tmp_out_build, tmp_out_quasimap, vcf_file, ref_file, reads_file, 150, kmer_size=5)
         # We're trusing gramtools output for this test. The point here is to check
         # that gramtools can run. Parsing its output is checked elsewhere.
         self.assertTrue(os.path.exists(tmp_out_build))
@@ -78,7 +78,7 @@ class TestGramtools(unittest.TestCase):
         ref_file = os.path.join(data_dir, 'run_gramtools.ref.fa')
         reads_file = os.path.join(data_dir, 'run_gramtools.reads.fq')
         with self.assertRaises(gramtools.Error):
-            gramtools.run_gramtools(tmp_out_build, tmp_out_quasimap, vcf_file, ref_file, reads_file, 150)
+            gramtools.run_gramtools(tmp_out_build, tmp_out_quasimap, vcf_file, ref_file, reads_file, 150, kmer_size=5)
         shutil.rmtree(tmp_out_build)
 
 
@@ -94,7 +94,7 @@ class TestGramtools(unittest.TestCase):
         ref_file = os.path.join(data_dir, 'run_gramtools.ref.fa')
         reads_file1 = os.path.join(data_dir, 'run_gramtools.reads_1.fq')
         reads_file2 = os.path.join(data_dir, 'run_gramtools.reads_2.fq')
-        gramtools.run_gramtools(tmp_out_build, tmp_out_quasimap, vcf_file, ref_file, [reads_file1, reads_file2], 150)
+        gramtools.run_gramtools(tmp_out_build, tmp_out_quasimap, vcf_file, ref_file, [reads_file1, reads_file2], 150, kmer_size=5)
         # We're trusing gramtools output for this test. The point here is to check
         # that gramtools can run. Parsing its output is checked elsewhere.
         self.assertTrue(os.path.exists(tmp_out_build))

--- a/minos/tests/vcf_chunker_test.py
+++ b/minos/tests/vcf_chunker_test.py
@@ -146,7 +146,7 @@ class TestVcfChunker(unittest.TestCase):
         vcf7 = cluster_vcf_records.vcf_record.VcfRecord('ref2\t42\t.\tC\tG\t.\tPASS\t.\t.\t.')
         header_lines = ['##header1', '##header2', '#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\tsample_name']
 
-        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=2, flank_length=1)
+        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=2, flank_length=1, gramtools_kmer_size=5)
         chunker.make_split_files()
         self.assertTrue(os.path.exists(chunker.metadata_pickle))
 
@@ -170,7 +170,7 @@ class TestVcfChunker(unittest.TestCase):
         shutil.rmtree(tmp_out)
 
 
-        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=4, flank_length=3)
+        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=4, flank_length=3, gramtools_kmer_size=5)
         chunker.make_split_files()
         self.assertTrue(os.path.exists(chunker.metadata_pickle))
 
@@ -188,7 +188,7 @@ class TestVcfChunker(unittest.TestCase):
 
         self.assertFalse(os.path.exists(os.path.join(tmp_out, 'split.3.in.vcf')))
 
-        chunker2 = vcf_chunker.VcfChunker(tmp_out)
+        chunker2 = vcf_chunker.VcfChunker(tmp_out, gramtools_kmer_size=5)
         self.assertEqual(chunker.vcf_infile,chunker2.vcf_infile)
         self.assertEqual(chunker.ref_fasta,chunker2.ref_fasta)
         self.assertEqual(chunker.variants_per_split,chunker2.variants_per_split)
@@ -212,20 +212,20 @@ class TestVcfChunker(unittest.TestCase):
         if os.path.exists(tmp_out):
             shutil.rmtree(tmp_out)
 
-        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=2, flank_length=200)
+        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=2, flank_length=200, gramtools_kmer_size=5)
         chunker.make_split_files()
         self.assertTrue(os.path.exists(chunker.metadata_pickle))
-        chunker2 = vcf_chunker.VcfChunker(tmp_out)
+        chunker2 = vcf_chunker.VcfChunker(tmp_out, gramtools_kmer_size=5)
         self.assertEqual(1, len(chunker2.vcf_split_files))
         self.assertEqual(3, len(chunker2.vcf_split_files['ref.0']))
         self.assertEqual(4, chunker2.vcf_split_files['ref.0'][-1].use_end_index)
         shutil.rmtree(tmp_out)
 
         # Test with two threads
-        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=2, flank_length=200, threads=2)
+        chunker = vcf_chunker.VcfChunker(tmp_out, vcf_infile=infile, ref_fasta=ref_fa, variants_per_split=2, flank_length=200, threads=2, gramtools_kmer_size=5)
         chunker.make_split_files()
         self.assertTrue(os.path.exists(chunker.metadata_pickle))
-        chunker2 = vcf_chunker.VcfChunker(tmp_out)
+        chunker2 = vcf_chunker.VcfChunker(tmp_out, gramtools_kmer_size=5)
         self.assertEqual(1, len(chunker2.vcf_split_files))
         self.assertEqual(3, len(chunker2.vcf_split_files['ref.0']))
         self.assertEqual(4, chunker2.vcf_split_files['ref.0'][-1].use_end_index)
@@ -237,7 +237,7 @@ class TestVcfChunker(unittest.TestCase):
         vcf_to_split = os.path.join(data_dir, 'merge_files.in.vcf')
         ref_fasta = os.path.join(data_dir, 'merge_files.in.ref.fa')
         tmp_outdir = 'tmp.vcf_chunker.merge_files'
-        chunker = vcf_chunker.VcfChunker(tmp_outdir, vcf_infile=vcf_to_split, ref_fasta=ref_fasta, variants_per_split=4, flank_length=3)
+        chunker = vcf_chunker.VcfChunker(tmp_outdir, vcf_infile=vcf_to_split, ref_fasta=ref_fasta, variants_per_split=4, flank_length=3, gramtools_kmer_size=5)
         chunker.make_split_files()
         to_merge = {}
         for ref, split_list in chunker.vcf_split_files.items():

--- a/minos/vcf_chunker.py
+++ b/minos/vcf_chunker.py
@@ -34,7 +34,7 @@ def _run_gramtools_build(split_file, ref_fasta, max_read_length, kmer_size):
 
 
 class VcfChunker:
-    def __init__(self, outdir, vcf_infile=None, ref_fasta=None, variants_per_split=None, max_read_length=200, total_splits=100, flank_length=200, gramtools_kmer_size=15, alleles_per_split=None, threads=1):
+    def __init__(self, outdir, vcf_infile=None, ref_fasta=None, variants_per_split=None, max_read_length=200, total_splits=100, flank_length=200, gramtools_kmer_size=10, alleles_per_split=None, threads=1):
         self.outdir = os.path.abspath(outdir)
         self.metadata_pickle = os.path.join(self.outdir, 'data.pickle')
         self.threads = threads


### PR DESCRIPTION
Need to use `--all-kmers` option with gramtools. This means previous k=15 default too big, so reduce to 10. But save memory for tests by using 5.