### PR TITLE
Fix off by one error reading BED files

### DIFF
--- a/minos/dnadiff_mapping_based_verifier.py
+++ b/minos/dnadiff_mapping_based_verifier.py
@@ -129,7 +129,7 @@ class DnadiffMappingBasedVerifier:
                     fields = line.rstrip().split('\t')
                     if fields[0] not in regions:
                         regions[fields[0]] = []
-                    start = int(fields[1]) - 1
+                    start = int(fields[1])
                     end = int(fields[2]) - 1
                     regions[fields[0]].append(pyfastaq.intervals.Interval(start, end))
 

--- a/minos/mapping_based_verifier.py
+++ b/minos/mapping_based_verifier.py
@@ -153,7 +153,7 @@ class MappingBasedVerifier:
                     fields = line.rstrip().split('\t')
                     if fields[0] not in regions:
                         regions[fields[0]] = []
-                    start = int(fields[1]) - 1
+                    start = int(fields[1])
                     end = int(fields[2]) - 1
                     regions[fields[0]].append(pyfastaq.intervals.Interval(start, end))
 

--- a/minos/tests/mapping_based_verifier_test.py
+++ b/minos/tests/mapping_based_verifier_test.py
@@ -64,7 +64,7 @@ class TestMappingBasedVerifier(unittest.TestCase):
 
     def test_load_exclude_regions_bed_file(self):
         '''test _load_exclude_regions_bed_file'''
-        i1 = pyfastaq.intervals.Interval(42, 43)
+        i1 = pyfastaq.intervals.Interval(42, 42)
         i2 = pyfastaq.intervals.Interval(50, 60)
         i3 = pyfastaq.intervals.Interval(100, 102)
 
@@ -75,10 +75,10 @@ class TestMappingBasedVerifier(unittest.TestCase):
 
         tmp_bed = 'tmp.load_exclude_regions_bed_file.bed'
         with open(tmp_bed, 'w') as f:
-            print('ref1',  43, 44, sep='\t', file=f)
-            print('ref1',  51, 55, sep='\t', file=f)
+            print('ref1',  42, 43, sep='\t', file=f)
+            print('ref1',  50, 56, sep='\t', file=f)
             print('ref1',  56, 61, sep='\t', file=f)
-            print('ref2',  101, 103, sep='\t', file=f)
+            print('ref2',  100, 103, sep='\t', file=f)
 
         self.assertEqual({}, mapping_based_verifier.MappingBasedVerifier._load_exclude_regions_bed_file(None))
         got = mapping_based_verifier.MappingBasedVerifier._load_exclude_regions_bed_file(tmp_bed)


### PR DESCRIPTION
BED file coords are 0-based, with `[n, m]` meaning from `n` to `(m-1)`. This fixes BED file reading, which was including `m` as part of the interval.