### PR TITLE
Call filtering

### DIFF
--- a/minos/__main__.py
+++ b/minos/__main__.py
@@ -99,6 +99,18 @@ def main(args=None):
         action="store_true",
         help="When using splitting (with --total_splits, --variants_per_split, or --alleles_per_split), use the unmapped reads with each split. Default is to ignore them. Using this option may add huge increase to run time, with little benefit to variant call accuracy",
     )
+    subparser_adjudicate.add_argument(
+        "--filter_min_dp",
+        type=int,
+        help="Minimum depth to be used for MIN_DP filter in output VCF file [%(default)s]",
+        default=5,
+    )
+    subparser_adjudicate.add_argument(
+        "--filter_min_gcp",
+        type=float,
+        help="Minimum genotype confidence percentile to be used for MIN_GCP filter in output VCF file [%(default)s]",
+        default=5.0,
+    )
     subparser_adjudicate.add_argument("outdir", help="Name of output directory")
     subparser_adjudicate.add_argument(
         "ref_fasta", help="Reference FASTA filename (must match VCF file(s))"

--- a/minos/tasks/adjudicate.py
+++ b/minos/tasks/adjudicate.py
@@ -19,5 +19,7 @@ def run(options):
         clean=not options.debug,
         gramtools_kmer_size=options.gramtools_kmer_size,
         use_unmapped_reads=options.use_unmapped_reads,
+        filter_min_dp=options.filter_min_dp,
+        filter_min_gcp=options.filter_min_gcp,
     )
     adj.run()

--- a/tests/adjudicator_test.py
+++ b/tests/adjudicator_test.py
@@ -191,7 +191,7 @@ class TestAdjudicator(unittest.TestCase):
         shutil.copyfile(original_file, tmp_file)
         error_rate = 0.00026045894282438386
         adjudicator.Adjudicator._add_gt_conf_percentile_and_filters_to_vcf_file(
-            tmp_file, 60, 100, error_rate, iterations=1000
+            tmp_file, 60, 100, error_rate, iterations=1000, min_dp=2, min_gcp=2.5
         )
         self.assertTrue(filecmp.cmp(tmp_file, expect_file, shallow=False))
         os.unlink(tmp_file)


### PR DESCRIPTION
Adds defaults of 5 for MIN_DP and MIN_GCP filters in output VCF file, and command line options to change them.