### PR TITLE
Do not cluster adjacent variants

### DIFF
--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -206,7 +206,7 @@ class Adjudicator:
                 self.vcf_files,
                 self.ref_fasta,
                 self.clustered_vcf,
-                max_distance_between_variants=1,
+                cluster_boundary_size=0,
                 max_alleles_per_cluster=self.max_alleles_per_cluster,
             )
             clusterer.run()

--- a/minos/dnadiff.py
+++ b/minos/dnadiff.py
@@ -247,6 +247,7 @@ class Dnadiff:
             self.query_fasta,
             self.merged_vcf,
             merge_method="simple",
+            cluster_boundary_size=31,
         )
         clusterer.run()
         header, self.variants = vcf_file_read.vcf_file_to_dict(

--- a/minos/dnadiff_mapping_based_verifier.py
+++ b/minos/dnadiff_mapping_based_verifier.py
@@ -680,14 +680,14 @@ class DnadiffMappingBasedVerifier:
                     self.vcf_reference_file,
                     self.clustered_vcf1,
                     merge_method="simple",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
                 clusterer2 = vcf_clusterer.VcfClusterer(
                     [self.filtered_vcf2],
                     self.vcf_reference_file,
                     self.clustered_vcf2,
                     merge_method="simple",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
             else:
                 clusterer1 = vcf_clusterer.VcfClusterer(
@@ -695,14 +695,14 @@ class DnadiffMappingBasedVerifier:
                     self.vcf_reference_file,
                     self.clustered_vcf1,
                     merge_method="gt_aware",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
                 clusterer2 = vcf_clusterer.VcfClusterer(
                     [self.filtered_vcf2],
                     self.vcf_reference_file,
                     self.clustered_vcf2,
                     merge_method="gt_aware",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
             clusterer1.run()
             clusterer2.run()

--- a/minos/evaluate_recall.py
+++ b/minos/evaluate_recall.py
@@ -570,14 +570,14 @@ class EvaluateRecall:
                     self.query_vcf_ref,
                     self.clustered_vcf_query,
                     merge_method="simple",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
                 clusterer_truth = vcf_clusterer.VcfClusterer(
                     [self.filtered_truth_vcf],
                     self.truth_vcf_ref,
                     self.clustered_vcf_truth,
                     merge_method="simple",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
             else:
                 clusterer_query = vcf_clusterer.VcfClusterer(
@@ -585,14 +585,14 @@ class EvaluateRecall:
                     self.query_vcf_ref,
                     self.clustered_vcf_query,
                     merge_method="gt_aware",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
                 clusterer_truth = vcf_clusterer.VcfClusterer(
                     [self.filtered_truth_vcf],
                     self.truth_vcf_ref,
                     self.clustered_vcf_truth,
                     merge_method="gt_aware",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
             clusterer_query.run()
             clusterer_truth.run()

--- a/minos/mapping_based_verifier.py
+++ b/minos/mapping_based_verifier.py
@@ -675,7 +675,7 @@ class MappingBasedVerifier:
                     self.vcf_reference_file,
                     self.clustered_vcf,
                     merge_method="simple",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
             else:
                 clusterer = vcf_clusterer.VcfClusterer(
@@ -683,7 +683,7 @@ class MappingBasedVerifier:
                     self.vcf_reference_file,
                     self.clustered_vcf,
                     merge_method="gt_aware",
-                    max_distance_between_variants=self.merge_length,
+                    cluster_boundary_size=self.merge_length,
                 )
             clusterer.run()
 

--- a/minos/multi_sample_pipeline.py
+++ b/minos/multi_sample_pipeline.py
@@ -375,7 +375,7 @@ process cluster_small_vars_vcf {
     """
     #!/usr/bin/env python3
     from cluster_vcf_records import vcf_clusterer
-    clusterer = vcf_clusterer.VcfClusterer(["pre_cluster_small_vars_merge.vcf"], "${ref_fasta}", "small_vars_clustered.vcf", max_alleles_per_cluster=${params.max_alleles_per_cluster})
+    clusterer = vcf_clusterer.VcfClusterer(["pre_cluster_small_vars_merge.vcf"], "${ref_fasta}", "small_vars_clustered.vcf", max_alleles_per_cluster=${params.max_alleles_per_cluster}, cluster_boundary_size=0)
     clusterer.run()
     """
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 biopython
-cluster_vcf_records >= 0.10.3
+cluster_vcf_records >= 0.11.0
 matplotlib
 pandas
 pyfastaq >= 3.14.0


### PR DESCRIPTION
Changes the initial clustering of records, so that adjacent VCF records do not get merged.