### PR TITLE
Default homozygous calling

### DIFF
--- a/Singularity.def
+++ b/Singularity.def
@@ -19,6 +19,8 @@ export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
     /minos/install_dependencies.sh /bioinf-tools
     cd /minos
     tox
+    # Getting pysam issue, complaining cython no found. So install it first.
+    pip3 install cython
     pip3 install .
 
 

--- a/minos/__main__.py
+++ b/minos/__main__.py
@@ -111,6 +111,11 @@ def main(args=None):
         help="Minimum genotype confidence percentile to be used for MIN_GCP filter in output VCF file [%(default)s]",
         default=5.0,
     )
+    subparser_adjudicate.add_argument(
+        "--no_het_calls",
+        action="store_true",
+        help="Do not consider heterozygous calls when genotyping each allele. Calls will all be homozygous.",
+    )
     subparser_adjudicate.add_argument("outdir", help="Name of output directory")
     subparser_adjudicate.add_argument(
         "ref_fasta", help="Reference FASTA filename (must match VCF file(s))"

--- a/minos/__main__.py
+++ b/minos/__main__.py
@@ -58,8 +58,9 @@ def main(args=None):
     subparser_adjudicate.add_argument(
         "--read_error_rate",
         type=float,
-        help="Read error rate. If not given, is estimated from quality scores of first 10,000 reads",
+        help="Read error rate between 0 and 1 [%(default)s]",
         metavar="FLOAT",
+        default=0.002,
     )
     subparser_adjudicate.add_argument(
         "--max_alleles_per_cluster",

--- a/minos/__main__.py
+++ b/minos/__main__.py
@@ -112,9 +112,9 @@ def main(args=None):
         default=5.0,
     )
     subparser_adjudicate.add_argument(
-        "--no_het_calls",
+        "--include_het_calls",
         action="store_true",
-        help="Do not consider heterozygous calls when genotyping each allele. Calls will all be homozygous.",
+        help="Consider heterozygous calls when genotyping each allele, instead of only making homozygous calls.",
     )
     subparser_adjudicate.add_argument("outdir", help="Name of output directory")
     subparser_adjudicate.add_argument(

--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -49,6 +49,7 @@ class Adjudicator:
         use_unmapped_reads=False,
         filter_min_dp=5,
         filter_min_gcp=5,
+        call_hets=True,
     ):
         self.ref_fasta = os.path.abspath(ref_fasta)
         self.reads_files = [os.path.abspath(x) for x in reads_files]
@@ -106,6 +107,7 @@ class Adjudicator:
         self.use_unmapped_reads = use_unmapped_reads
         self.filter_min_dp = filter_min_dp
         self.filter_min_gcp = filter_min_gcp
+        self.call_hets = call_hets
         self.ref_seq_lengths = {x.id.split()[0]: len(x) for x in pyfastaq.sequences.file_reader(self.ref_fasta)}
 
     def build_output_dir(self):
@@ -418,6 +420,7 @@ class Adjudicator:
             max_read_length=self.max_read_length,
             filtered_outfile=final_vcf,
             ref_seq_lengths=self.ref_seq_lengths,
+            call_hets=self.call_hets,
         )
 
     def run_gt_conf(self):

--- a/minos/genotype_confidence_simulator.py
+++ b/minos/genotype_confidence_simulator.py
@@ -7,7 +7,7 @@ from minos import genotyper
 
 class GenotypeConfidenceSimulator:
     def __init__(
-        self, mean_depth, depth_variance, error_rate, allele_length=1, iterations=10000
+        self, mean_depth, depth_variance, error_rate, allele_length=1, iterations=10000, call_hets=True
     ):
         self.mean_depth = mean_depth
         self.depth_variance = depth_variance
@@ -17,6 +17,7 @@ class GenotypeConfidenceSimulator:
         self.confidence_scores_percentiles = {}
         self.min_conf_score = None
         self.max_conf_score = None
+        self.call_hets = call_hets
 
     @classmethod
     def _simulate_confidence_scores(
@@ -27,6 +28,7 @@ class GenotypeConfidenceSimulator:
         iterations,
         allele_length=1,
         seed=42,
+        call_hets=True,
     ):
         np.random.seed(seed)
         allele_groups_dict = {"1": {0}, "2": {1}}
@@ -65,6 +67,7 @@ class GenotypeConfidenceSimulator:
                 allele_combination_cov,
                 allele_per_base_cov,
                 allele_groups_dict,
+                call_hets=call_hets,
             )
             gtyper.run()
             confidences.append(round(gtyper.genotype_confidence))
@@ -157,6 +160,7 @@ class GenotypeConfidenceSimulator:
             self.error_rate,
             self.iterations,
             allele_length=self.allele_length,
+            call_hets=self.call_hets,
         )
         self.confidence_scores_percentiles = GenotypeConfidenceSimulator._make_conf_to_percentile_dict(
             confidence_scores

--- a/minos/genotyper.py
+++ b/minos/genotyper.py
@@ -14,6 +14,7 @@ class Genotyper:
         allele_per_base_cov,
         allele_groups_dict,
         min_cov_more_than_error=None,
+        call_hets=True,
     ):
         self.mean_depth = mean_depth
         self.error_rate = error_rate
@@ -31,6 +32,7 @@ class Genotyper:
             )
         else:
             self.min_cov_more_than_error = min_cov_more_than_error
+        self.call_hets = call_hets
 
     @classmethod
     def get_min_cov_to_be_more_likely_than_error(cls, mean_depth, error_rate):
@@ -207,6 +209,10 @@ class Genotyper:
         self.singleton_allele_coverages = Genotyper._singleton_alleles_and_coverage(
             self.allele_combination_cov, self.allele_groups_dict
         )
+
+        if not self.call_hets:
+            self.likelihoods.sort(key=operator.itemgetter(1), reverse=True)
+            return
 
         for (allele_number1, allele_number2) in itertools.combinations(
             self.singleton_allele_coverages.keys(), 2

--- a/minos/genotyper.py
+++ b/minos/genotyper.py
@@ -23,6 +23,7 @@ class Genotyper:
         self.allele_groups_dict = allele_groups_dict
         self.likelihoods = None
         self.genotype = None
+        self.genotype_frs = None
         self.genotype_confidence = None
         self.singleton_allele_coverages = {}
         self.haploid_allele_coverages = []
@@ -204,7 +205,8 @@ class Genotyper:
                 allele_length,
                 non_zeros,
             )
-            self.likelihoods.append(({allele_number, allele_number}, log_likelihood))
+            frac_support = 0 if total_depth == 0 else round(allele_depth / total_depth, 4)
+            self.likelihoods.append(({allele_number, allele_number}, log_likelihood, frac_support))
 
         self.singleton_allele_coverages = Genotyper._singleton_alleles_and_coverage(
             self.allele_combination_cov, self.allele_groups_dict
@@ -239,8 +241,9 @@ class Genotyper:
                 non_zeros1,
                 non_zeros2,
             )
+            frac_support = 0 if total_depth == 0 else round((allele1_depth + allele2_depth) / total_depth, 4)
             self.likelihoods.append(
-                (set([allele_number1, allele_number2]), log_likelihood)
+                (set([allele_number1, allele_number2]), log_likelihood, frac_support)
             )
 
         self.likelihoods.sort(key=operator.itemgetter(1), reverse=True)
@@ -253,15 +256,17 @@ class Genotyper:
         ):
             self.genotype = {"."}
             self.genotype_confidence = 0.0
+            self.genotype_frs = "."
         else:
             self._calculate_log_likelihoods()
             assert self.likelihoods is not None and len(self.likelihoods) > 1
-            self.genotype, best_log_likelihood = self.likelihoods[0]
+            self.genotype, best_log_likelihood, self.genotype_frs = self.likelihoods[0]
 
             for allele in self.genotype:
                 if self.singleton_allele_coverages.get(allele, 0) == 0:
                     self.genotype = {"."}
                     self.genotype_confidence = 0.0
+                    self.genotype_frs = 0
                     break
             else:
                 self.genotype_confidence = round(

--- a/minos/gramtools.py
+++ b/minos/gramtools.py
@@ -263,6 +263,7 @@ def update_vcf_record_using_gramtools_allele_depths(
     vcf_record.set_format_key_value("DP", str(sum(allele_combination_cov.values())))
     vcf_record.set_format_key_value("GT", genotype)
     vcf_record.set_format_key_value("COV", cov_string)
+    vcf_record.set_format_key_value("FRS", str(gtyper.genotype_frs))
     vcf_record.set_format_key_value("GT_CONF", str(gtyper.genotype_confidence))
 
     # Make new record where all zero coverage alleles are removed
@@ -329,6 +330,7 @@ def write_vcf_annotated_using_coverage_from_gramtools(
         "##source=minos, version " + minos_version,
         "##fileDate=" + str(datetime.date.today()),
         '##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">',
+        '##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">',
         '##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">',
         '##FORMAT=<ID=DP,Number=1,Type=Integer,Description="total read depth from gramtools">',
         '##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">',

--- a/minos/gramtools.py
+++ b/minos/gramtools.py
@@ -216,6 +216,7 @@ def update_vcf_record_using_gramtools_allele_depths(
     mean_depth,
     read_error_rate,
     min_cov_more_than_error=None,
+    call_hets=True,
 ):
     """allele_depths should be a dict of allele -> coverage.
     The REF allele must also be in the dict.
@@ -230,6 +231,7 @@ def update_vcf_record_using_gramtools_allele_depths(
         allele_per_base_cov,
         allele_groups_dict,
         min_cov_more_than_error=min_cov_more_than_error,
+        call_hets=call_hets,
     )
     gtyper.run()
     genotype_indexes = set()
@@ -315,6 +317,7 @@ def write_vcf_annotated_using_coverage_from_gramtools(
     max_read_length=None,
     filtered_outfile=None,
     ref_seq_lengths=None,
+    call_hets=True,
 ):
     """mean_depth, vcf_records, all_allele_coverage, allele_groups should be those
     returned by load_gramtools_vcf_and_allele_coverage_files().
@@ -376,6 +379,7 @@ def write_vcf_annotated_using_coverage_from_gramtools(
                 mean_depth,
                 read_error_rate,
                 min_cov_more_than_error=min_cov_more_than_error,
+                call_hets=call_hets,
             )
             print(vcf_records[i], file=f)
             if filtered_outfile is not None:

--- a/minos/tasks/adjudicate.py
+++ b/minos/tasks/adjudicate.py
@@ -21,5 +21,6 @@ def run(options):
         use_unmapped_reads=options.use_unmapped_reads,
         filter_min_dp=options.filter_min_dp,
         filter_min_gcp=options.filter_min_gcp,
+        call_hets=not options.no_het_calls,
     )
     adj.run()

--- a/minos/tasks/adjudicate.py
+++ b/minos/tasks/adjudicate.py
@@ -21,6 +21,6 @@ def run(options):
         use_unmapped_reads=options.use_unmapped_reads,
         filter_min_dp=options.filter_min_dp,
         filter_min_gcp=options.filter_min_gcp,
-        call_hets=not options.no_het_calls,
+        call_hets=options.include_het_calls,
     )
     adj.run()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="bio-minos",
-    version="0.9.1",
+    version="0.10.0",
     description="Variant call adjudication",
     packages=find_packages(),
     author="Martin Hunt",

--- a/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf
+++ b/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf
@@ -1,13 +1,14 @@
 ##fileformat=VCFv4.2
-##source=minos, version 0.4.1
-##fileDate=2019-02-22
+##source=minos, version 0.9.1
+##fileDate=2020-03-04
 ##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
+##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="total read depth from gramtools">
 ##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">
 ##contig=<ID=ref,length=10000>
 ##minos_max_read_length=200
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_42
-ref	1	.	G	T	.	.	.	DP:GT:COV:GT_CONF	11:1/1:0,10:11.15
-ref	2	.	A	C,TA,G	.	.	.	DP:GT:COV:GT_CONF	10:2/3:1,0,3,5:18.2
-ref	42	.	A	G	.	.	.	DP:GT:COV:GT_CONF	0:./.:0,0:0.0
+ref	1	.	G	T	.	.	.	GT:DP:COV:FRS:GT_CONF	1/1:11:0,10:1.0:11.15
+ref	2	.	A	C,TA,G	.	.	.	GT:DP:COV:FRS:GT_CONF	2/3:10:1,0,3,5:0.9:18.2
+ref	42	.	A	G	.	.	.	GT:DP:COV:FRS:GT_CONF	./.:0:0,0:.:0.0

--- a/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf.filter.vcf
+++ b/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf.filter.vcf
@@ -1,13 +1,14 @@
 ##fileformat=VCFv4.2
-##source=minos, version 0.4.1
-##fileDate=2019-02-22
+##source=minos, version 0.9.1
+##fileDate=2020-03-04
 ##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
+##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="total read depth from gramtools">
 ##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">
 ##contig=<ID=ref,length=10000>
 ##minos_max_read_length=200
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_42
-ref	1	.	G	T	.	.	.	DP:GT:COV:GT_CONF	11:1/1:0,10:11.15
-ref	2	.	A	TA,G	.	.	.	DP:GT:COV:GT_CONF	10:1/2:1,3,5:18.2
-ref	42	.	A	G	.	.	.	DP:GT:COV:GT_CONF	0:./.:0,0:0.0
+ref	1	.	G	T	.	.	.	GT:DP:COV:FRS:GT_CONF	1/1:11:0,10:1.0:11.15
+ref	2	.	A	TA,G	.	.	.	GT:DP:COV:FRS:GT_CONF	1/2:10:1,3,5:0.9:18.2
+ref	42	.	A	G	.	.	.	GT:DP:COV:FRS:GT_CONF	./.:0:0,0:.:0.0

--- a/tests/genotype_confidence_simulator_test.py
+++ b/tests/genotype_confidence_simulator_test.py
@@ -62,6 +62,21 @@ class TestGenotypeConfidenceSimulator(unittest.TestCase):
         self.assertEqual(100.00, simulator.get_percentile(51))
         self.assertEqual(100.00, simulator.get_percentile(52))
 
+    def test_run_simulations_and_get_percentile_allele_length_1_no_het_calls(self):
+        """test run_simulations and get_percentile with no het calls"""
+        simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
+            50, 300, 0.1, iterations=5, call_hets=False,
+        )
+        simulator.run_simulations()
+        expected_confidence_scores_percentiles = {
+            149: 20.0, 164: 40.0, 193: 60.0, 200: 80.0, 215: 100.0,
+        }
+        self.assertEqual(
+            expected_confidence_scores_percentiles,
+            simulator.confidence_scores_percentiles,
+        )
+        self.assertEqual(80.00, simulator.get_percentile(200))
+
     def test_run_simulations_and_get_percentile_allele_length_2(self):
         """test run_simulations and get_percentile"""
         simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(

--- a/tests/genotyper_test.py
+++ b/tests/genotyper_test.py
@@ -158,6 +158,28 @@ class TestGenotyper(unittest.TestCase):
         gtyper.likelihoods = [(x[0], round(x[1], 2)) for x in gtyper.likelihoods]
         self.assertEqual(expected, gtyper.likelihoods)
 
+    def test_run_with_call_hets_false(self):
+        """test run"""
+        mean_depth = 20
+        error_rate = 0.01
+        allele_combination_cov = {"1": 2, "2": 20, "3": 1}
+        allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
+        allele_per_base_cov = [[0, 1], [20, 19]]
+        gtyper = genotyper.Genotyper(
+            mean_depth,
+            error_rate,
+            allele_combination_cov,
+            allele_per_base_cov,
+            allele_groups_dict,
+            call_hets=False,
+        )
+        expected = [({1}, -11.68), ({0}, -124.91)]
+        gtyper.run()
+        self.assertEqual(len(expected), len(gtyper.likelihoods))
+        for i in range(len(expected)):
+            self.assertEqual(expected[i][0], gtyper.likelihoods[i][0])
+            self.assertAlmostEqual(expected[i][1], gtyper.likelihoods[i][1], places=2)
+
     def test_run(self):
         """test run"""
         mean_depth = 20

--- a/tests/genotyper_test.py
+++ b/tests/genotyper_test.py
@@ -152,10 +152,13 @@ class TestGenotyper(unittest.TestCase):
             allele_per_base_cov,
             allele_groups_dict,
         )
+        depth0 = round(3/23, 4)
+        depth01 = 1
+        depth1 = round(21/23, 4)
         gtyper._calculate_log_likelihoods()
-        expected = [({1}, -11.68), ({0, 1}, -22.92), ({0}, -124.91)]
+        expected = [({1}, -11.68, depth1), ({0, 1}, -22.92, depth01), ({0}, -124.91, depth0)]
         self.assertEqual(3, len(gtyper.likelihoods))
-        gtyper.likelihoods = [(x[0], round(x[1], 2)) for x in gtyper.likelihoods]
+        gtyper.likelihoods = [(x[0], round(x[1], 2), x[2]) for x in gtyper.likelihoods]
         self.assertEqual(expected, gtyper.likelihoods)
 
     def test_run_with_call_hets_false(self):
@@ -173,12 +176,16 @@ class TestGenotyper(unittest.TestCase):
             allele_groups_dict,
             call_hets=False,
         )
-        expected = [({1}, -11.68), ({0}, -124.91)]
+        depth0 = round(3/23, 4)
+        depth01 = 1
+        depth1 = round(21/23, 4)
+        expected = [({1}, -11.68, depth1), ({0}, -124.91, depth0)]
         gtyper.run()
         self.assertEqual(len(expected), len(gtyper.likelihoods))
         for i in range(len(expected)):
             self.assertEqual(expected[i][0], gtyper.likelihoods[i][0])
             self.assertAlmostEqual(expected[i][1], gtyper.likelihoods[i][1], places=2)
+            self.assertEqual(expected[i][2], gtyper.likelihoods[i][2])
 
     def test_run(self):
         """test run"""
@@ -194,12 +201,16 @@ class TestGenotyper(unittest.TestCase):
             allele_per_base_cov,
             allele_groups_dict,
         )
-        expected = [({1}, -11.68), ({0, 1}, -22.92), ({0}, -124.91)]
+        depth0 = round(3/23, 4)
+        depth01 = 1
+        depth1 = round(21/23, 4)
+        expected = [({1}, -11.68, depth1), ({0, 1}, -22.92, depth01), ({0}, -124.91, depth0)]
         gtyper.run()
         self.assertEqual(len(expected), len(gtyper.likelihoods))
         for i in range(len(expected)):
             self.assertEqual(expected[i][0], gtyper.likelihoods[i][0])
             self.assertAlmostEqual(expected[i][1], gtyper.likelihoods[i][1], places=2)
+            self.assertEqual(expected[i][2], gtyper.likelihoods[i][2])
 
     def test_run_zero_coverage(self):
         """test run when all alleles have zero coverage"""
@@ -218,6 +229,7 @@ class TestGenotyper(unittest.TestCase):
         gtyper.run()
         self.assertEqual({"."}, gtyper.genotype)
         self.assertEqual(0.0, gtyper.genotype_confidence)
+        self.assertEqual(".", gtyper.genotype_frs)
 
     def test_nomatherror_mean_depth0(self):
         """
@@ -239,3 +251,4 @@ class TestGenotyper(unittest.TestCase):
         gtyper.run()
         self.assertEqual({"."}, gtyper.genotype)
         self.assertEqual(0.0, gtyper.genotype_confidence)
+        self.assertEqual(".", gtyper.genotype_frs)

--- a/tests/gramtools_test.py
+++ b/tests/gramtools_test.py
@@ -206,7 +206,7 @@ class TestGramtools(unittest.TestCase):
         allele_groups_dict = {"1": {0}, "2": {2}, "3": {2, 3}}
         allele_per_base_cov = [[0], [9], [7], [1, 0]]
         expected = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tA,G,TC\t.\t.\t.\tGT:DP:COV:GT_CONF\t0/2:17:9,0,7,0:54.46"
+                "ref\t4\t.\tT\tA,G,TC\t.\t.\t.\tGT:DP:COV:FRS:GT_CONF\t0/2:17:9,0,7,0:1.0:54.46"
         )
         mean_depth = 15
         error_rate = 0.001
@@ -220,7 +220,7 @@ class TestGramtools(unittest.TestCase):
         )
         self.assertEqual(expected, record)
         expected_filtered = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:COV:GT_CONF\t0/1:17:9,7:54.46"
+                "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:COV:FRS:GT_CONF\t0/1:17:9,7:1.0:54.46"
         )
         self.assertEqual(expected_filtered, got_filtered)
 
@@ -233,7 +233,7 @@ class TestGramtools(unittest.TestCase):
         allele_groups_dict = {"1": {0}, "2": {2}, "3": {1, 2}}
         allele_per_base_cov = [[1], [0, 0], [80]]
         expected = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tTC,G\t.\t.\t.\tGT:DP:COV:GT_CONF\t2/2:81:1,0,80:87.29"
+            "ref\t4\t.\tT\tTC,G\t.\t.\t.\tGT:DP:COV:FRS:GT_CONF\t2/2:81:1,0,80:0.9877:87.29"
         )
         mean_depth = 85
         error_rate = 0.001
@@ -247,7 +247,7 @@ class TestGramtools(unittest.TestCase):
         )
         self.assertEqual(expected, record)
         expected_filtered = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:COV:GT_CONF\t1/1:81:1,80:87.29"
+                "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:COV:FRS:GT_CONF\t1/1:81:1,80:0.9877:87.29"
         )
         self.assertEqual(expected_filtered, got_filtered)
 
@@ -260,7 +260,7 @@ class TestGramtools(unittest.TestCase):
         allele_groups_dict = {"1": {0}}
         allele_per_base_cov = [[0], [0], [0, 0]]
         expected = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG,TC\t.\t.\t.\tGT:DP:COV:GT_CONF\t./.:0:0,0,0:0.0"
+            "ref\t4\t.\tT\tG,TC\t.\t.\t.\tGT:DP:COV:FRS:GT_CONF\t./.:0:0,0,0:.:0.0"
         )
         mean_depth = 85
         error_rate = 0.001


### PR DESCRIPTION
* by default, genotype model only considers homozygous calls
* defaults to using 0.002 for read error rate instead of mean of qual scores
* new FRS tag in vcf = Fraction of Reads Supporting genotype call

This leaves the question of default filter cutoffs for homozygous calling. Address this once we can reliably evaluate VCF files.