### PR TITLE
Genotyping distributions fixes

### DIFF
--- a/minos/__main__.py
+++ b/minos/__main__.py
@@ -104,7 +104,7 @@ def main(args=None):
         "--filter_min_dp",
         type=int,
         help="Minimum depth to be used for MIN_DP filter in output VCF file [%(default)s]",
-        default=0,
+        default=2,
     )
     subparser_adjudicate.add_argument(
         "--filter_min_frs",
@@ -116,7 +116,7 @@ def main(args=None):
         "--filter_min_gcp",
         type=float,
         help="Minimum genotype confidence percentile to be used for MIN_GCP filter in output VCF file [%(default)s]",
-        default=5.0,
+        default=2.5,
     )
     subparser_adjudicate.add_argument(
         "--include_het_calls",

--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -53,7 +53,7 @@ class Adjudicator:
         filter_min_dp=0,
         filter_min_gcp=5,
         filter_min_frs=0.9,
-        call_hets=True,
+        call_hets=False,
         debug=False,
     ):
         self.ref_fasta = os.path.abspath(ref_fasta)
@@ -115,7 +115,10 @@ class Adjudicator:
         self.filter_min_frs = filter_min_frs
         self.call_hets = call_hets
         self.debug = debug
-        self.ref_seq_lengths = {x.id.split()[0]: len(x) for x in pyfastaq.sequences.file_reader(self.ref_fasta)}
+        self.ref_seq_lengths = {
+            x.id.split()[0]: len(x)
+            for x in pyfastaq.sequences.file_reader(self.ref_fasta)
+        }
 
     def build_output_dir(self):
         try:
@@ -158,6 +161,8 @@ class Adjudicator:
             return input_kmer_size
 
     def run(self):
+        Adjudicator.mean_depths = []
+        Adjudicator.variance_depths = []
         self.build_output_dir()
 
         fh = logging.FileHandler(self.log_file, mode="w")
@@ -175,7 +180,10 @@ class Adjudicator:
             logging.info(
                 "One or both of read_error_rate and max_read_length not known. Estimate from first 10,000 reads..."
             )
-            estimated_read_length, estimated_read_error_rate = utils.estimate_max_read_length_and_read_error_rate_from_qual_scores(
+            (
+                estimated_read_length,
+                estimated_read_error_rate,
+            ) = utils.estimate_max_read_length_and_read_error_rate_from_qual_scores(
                 self.reads_files[0]
             )
             logging.info(
@@ -387,7 +395,14 @@ class Adjudicator:
         build_vcf = os.path.join(build_dir, "build.vcf")
 
         logging.info("Loading gramtools quasimap output files " + quasimap_dir)
-        mean_depth, variance_depth, vcf_header, vcf_records, allele_coverage, allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
+        (
+            mean_depth,
+            variance_depth,
+            vcf_header,
+            vcf_records,
+            allele_coverage,
+            allele_groups,
+        ) = gramtools.load_gramtools_vcf_and_allele_coverage_files(
             build_vcf, quasimap_dir
         )
         Adjudicator.mean_depths.append(mean_depth)
@@ -418,6 +433,7 @@ class Adjudicator:
 
         gramtools.write_vcf_annotated_using_coverage_from_gramtools(
             mean_depth,
+            variance_depth,
             vcf_records,
             allele_coverage,
             allele_groups,
@@ -429,7 +445,6 @@ class Adjudicator:
             ref_seq_lengths=self.ref_seq_lengths,
             call_hets=self.call_hets,
         )
-
 
     @classmethod
     def _plot_gt_conf_hists(cls, real_file, sim_file, outfile):
@@ -451,13 +466,26 @@ class Adjudicator:
         plt.clf()
         plt.close("all")
 
-
     def run_gt_conf(self):
-        """
-        """
-
         mean_depth = statistics.mean(Adjudicator.mean_depths)
         variance_depth = statistics.mean(Adjudicator.variance_depths)
+
+        if mean_depth > 0:
+            simulations = genotype_confidence_simulator.GenotypeConfidenceSimulator(
+                mean_depth,
+                variance_depth,
+                self.read_error_rate,
+                allele_length=1,
+                iterations=self.genotype_simulation_iterations,
+                call_hets=self.call_hets,
+            )
+            if self.debug:
+                sim_conf_scores_file = f"debug.genotype_sim_conf_scores.txt"
+            else:
+                sim_conf_scores_file = None
+            simulations.run_simulations(conf_scores_file=sim_conf_scores_file)
+        else:
+            simulations = None
 
         logging.info(
             f"Adding GT_CONF_PERCENTLE to final VCF file {self.final_vcf} & its debug counterpart, "
@@ -466,57 +494,38 @@ class Adjudicator:
         )
 
         for f in [self.unfiltered_vcf_file, self.final_vcf]:
-            debug_out = f + ".debug" if self.debug else None
+            if self.debug and f == self.final_vcf:
+                scores_file = "debug.genotype_real_conf_scores.txt"
+            else:
+                scores_file = None
             Adjudicator._add_gt_conf_percentile_and_filters_to_vcf_file(
                 f,
-                mean_depth,
-                variance_depth,
-                self.read_error_rate,
-                self.genotype_simulation_iterations,
+                simulations,
                 min_dp=self.filter_min_dp,
                 min_gcp=self.filter_min_gcp,
                 min_frs=self.filter_min_frs,
-                debug_out=debug_out,
-                call_hets=self.call_hets,
+                conf_scores_file=scores_file,
             )
-            if self.debug:
-                real_file = f"{f}.debug.real_conf_scores.txt"
-                sim_file = f"{f}.debug.sim_conf_scores.txt"
-                outfile = f"{f}.debug.histogram.pdf"
-                Adjudicator._plot_gt_conf_hists(real_file, sim_file, outfile)
+            if scores_file is not None:
+                Adjudicator._plot_gt_conf_hists(
+                    scores_file, sim_conf_scores_file, "debug.genotype_hist.pdf"
+                )
 
     @classmethod
     def _add_gt_conf_percentile_and_filters_to_vcf_file(
         cls,
         vcf_file,
-        mean_depth,
-        depth_variance,
-        error_rate,
-        iterations,
+        geno_simulations,
         min_dp=0,
         min_gcp=5,
         min_frs=0.9,
-        debug_out=None,
-        call_hets=True,
+        conf_scores_file=None,
     ):
         """Overwrites vcf_file, with new version that has GT_CONF_PERCENTILE added,
         and filter for DP, GT_CONF_PERCENTILE, and FRS"""
-        if debug_out is None:
-            sim_conf_scores_file = None
-        else:
-            sim_conf_scores_file = f"{debug_out}.sim_conf_scores.txt"
+        if conf_scores_file is not None:
             real_conf_scores = []
 
-        if mean_depth > 0:
-            simulations = genotype_confidence_simulator.GenotypeConfidenceSimulator(
-                mean_depth,
-                depth_variance,
-                error_rate,
-                allele_length=1,
-                iterations=iterations,
-                call_hets=call_hets,
-            )
-            simulations.run_simulations(conf_scores_file=sim_conf_scores_file)
         vcf_header, vcf_lines = vcf_file_read.vcf_file_to_list(vcf_file)
         for i, line in enumerate(vcf_header):
             if line.startswith("##FORMAT=<ID=GT_CONF"):
@@ -526,20 +535,12 @@ class Adjudicator:
                 f"No GT_CONF description found in header of VCF file {vcf_file}. Cannot continue"
             )
 
-        vcf_header.insert(
-            i + 1,
-            r"""##FORMAT=<ID=GT_CONF_PERCENTILE,Number=1,Type=Float,Description="Percentile of GT_CONF">""",
-        )
-        vcf_header.insert(
-            i + 1, f'##FILTER=<ID=MIN_FRS,Description="Minimum FRS of {min_frs}">'
-        )
-        vcf_header.insert(
-            i + 1, f'##FILTER=<ID=MIN_DP,Description="Minimum DP of {min_dp}">'
-        )
-        vcf_header.insert(
-            i + 1,
+        vcf_header[i + 1 : i + 1] = [
+            '##FORMAT=<ID=GT_CONF_PERCENTILE,Number=1,Type=Float,Description="Percentile of GT_CONF">',
+            f'##FILTER=<ID=MIN_FRS,Description="Minimum FRS of {min_frs}">',
+            f'##FILTER=<ID=MIN_DP,Description="Minimum DP of {min_dp}">',
             f'##FILTER=<ID=MIN_GCP,Description="Minimum GT_CONF_PERCENTILE of {min_gcp}">',
-        )
+        ]
 
         with open(vcf_file, "w") as f:
             print(*vcf_header, sep="\n", file=f)
@@ -551,7 +552,8 @@ class Adjudicator:
                     if "." not in vcf_record.FORMAT["GT"]:
                         conf = int(round(float(vcf_record.FORMAT["GT_CONF"])))
                         vcf_record.set_format_key_value(
-                            "GT_CONF_PERCENTILE", str(simulations.get_percentile(conf))
+                            "GT_CONF_PERCENTILE",
+                            str(geno_simulations.get_percentile(conf)),
                         )
                         if (
                             "DP" in vcf_record.FORMAT
@@ -560,12 +562,15 @@ class Adjudicator:
                             vcf_record.FILTER.add("MIN_DP")
                         if float(vcf_record.FORMAT["GT_CONF_PERCENTILE"]) < min_gcp:
                             vcf_record.FILTER.add("MIN_GCP")
-                        if "FRS" in vcf_record.FORMAT and float(vcf_record.FORMAT["FRS"]) < min_frs:
+                        if (
+                            "FRS" in vcf_record.FORMAT
+                            and float(vcf_record.FORMAT["FRS"]) < min_frs
+                        ):
                             vcf_record.FILTER.add("MIN_FRS")
                         if len(vcf_record.FILTER) == 0:
                             vcf_record.FILTER.add("PASS")
 
-                        if debug_out is not None:
+                        if conf_scores_file is not None:
                             real_conf_scores.append(conf)
                     else:
                         # Add a default null percentile
@@ -573,7 +578,6 @@ class Adjudicator:
 
                 print(vcf_record, file=f)
 
-        if debug_out is not None:
-            with open(f"{debug_out}.real_conf_scores.txt", "w") as f:
+        if conf_scores_file is not None:
+            with open(conf_scores_file, "w") as f:
                 print(*real_conf_scores, sep="\n", file=f)
-

--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -434,7 +434,7 @@ class Adjudicator:
             if not self.user_supplied_gramtools_build_dir:
                 os.rename(
                     os.path.join(build_dir, "build_report.json"),
-                    os.path.join(build_dir, "build.report.json"),
+                    build_dir + ".report.json",
                 )
                 shutil.rmtree(build_dir)
 

--- a/minos/adjudicator.py
+++ b/minos/adjudicator.py
@@ -119,6 +119,20 @@ class Adjudicator:
             x.id.split()[0]: len(x)
             for x in pyfastaq.sequences.file_reader(self.ref_fasta)
         }
+        if self.debug:
+            self.sim_conf_scores_file = os.path.join(
+                self.outdir, "debug.genotype_sim_conf_scores.txt"
+            )
+            self.real_conf_scores_file = os.path.join(
+                self.outdir, "debug.genotype_real_conf_scores.txt"
+            )
+            self.genotype_hist_pdf = os.path.join(
+                self.outdir, "debug.genotype_hist.pdf"
+            )
+        else:
+            self.sim_conf_scores_file = None
+            self.real_conf_scores_file = None
+            self.genotype_hist_pdf = None
 
     def build_output_dir(self):
         try:
@@ -479,11 +493,7 @@ class Adjudicator:
                 iterations=self.genotype_simulation_iterations,
                 call_hets=self.call_hets,
             )
-            if self.debug:
-                sim_conf_scores_file = f"debug.genotype_sim_conf_scores.txt"
-            else:
-                sim_conf_scores_file = None
-            simulations.run_simulations(conf_scores_file=sim_conf_scores_file)
+            simulations.run_simulations(conf_scores_file=self.sim_conf_scores_file)
         else:
             simulations = None
 
@@ -495,7 +505,7 @@ class Adjudicator:
 
         for f in [self.unfiltered_vcf_file, self.final_vcf]:
             if self.debug and f == self.final_vcf:
-                scores_file = "debug.genotype_real_conf_scores.txt"
+                scores_file = self.real_conf_scores_file
             else:
                 scores_file = None
             Adjudicator._add_gt_conf_percentile_and_filters_to_vcf_file(
@@ -508,7 +518,7 @@ class Adjudicator:
             )
             if scores_file is not None:
                 Adjudicator._plot_gt_conf_hists(
-                    scores_file, sim_conf_scores_file, "debug.genotype_hist.pdf"
+                    scores_file, self.sim_conf_scores_file, self.genotype_hist_pdf,
                 )
 
     @classmethod

--- a/minos/dependencies.py
+++ b/minos/dependencies.py
@@ -50,7 +50,7 @@ def find_python_packages():
     package_name => (version, path).
     Values will be None if package not found"""
     packages = {}
-    for package in ["minos", "pyfastaq", "pysam"]:
+    for package in ["cluster_vcf_records", "matplotlib", "minos", "pyfastaq", "pysam", "scipy", "seaborn"]:
         try:
             exec("import " + package)
             version = eval(package + ".__version__")

--- a/minos/genotype_confidence_simulator.py
+++ b/minos/genotype_confidence_simulator.py
@@ -7,7 +7,13 @@ from minos import genotyper
 
 class GenotypeConfidenceSimulator:
     def __init__(
-        self, mean_depth, depth_variance, error_rate, allele_length=1, iterations=10000, call_hets=True
+        self,
+        mean_depth,
+        depth_variance,
+        error_rate,
+        allele_length=1,
+        iterations=10000,
+        call_hets=False,
     ):
         self.mean_depth = mean_depth
         self.depth_variance = depth_variance
@@ -28,29 +34,27 @@ class GenotypeConfidenceSimulator:
         iterations,
         allele_length=1,
         seed=42,
-        call_hets=True,
+        call_hets=False,
     ):
         np.random.seed(seed)
         allele_groups_dict = {"1": {0}, "2": {1}}
         i = 0
         confidences = []
-        #  We can't use the negative binomial unless depth_variance > mean_depth.
-        # So force it to be so.
-        #if depth_variance < mean_depth:
-        #    depth_variance = 2 * mean_depth
-        #    logging.warn(
-        #        "Variance in read depth is smaller than mean read depth. Setting variance = 2 * mean, so that variant simulations can run. GT_CONF_PERCENTILE in the output VCF file may not be very useful as a result of this."
-        #    )
-        #no_of_successes = (mean_depth ** 2) / (depth_variance - mean_depth)
-        #prob_of_success = 1 - (depth_variance - mean_depth) / depth_variance
-        #logging.debug(f"Start simulation. mean_depth={mean_depth}, depth_variance={depth_variance}, error_rate={error_rate}, iterations={iterations}, call_hets={call_hets}")
-        logging.debug("Simulation:\titeration\tcorrect_coverage\tincorrect_coverage\tgenotype_confidence")
+        gtyper = genotyper.Genotyper(
+            mean_depth, depth_variance, error_rate, call_hets=call_hets,
+        )
+        logging.debug(
+            "Simulation:\titeration\tcorrect_coverage\tincorrect_coverage\tgenotype_confidence"
+        )
 
         while i < iterations:
-            #correct_coverage = np.random.negative_binomial(
-            #    no_of_successes, prob_of_success
-            #)
-            correct_coverage = np.random.poisson(mean_depth)
+            if gtyper.use_nbinom:
+                correct_coverage = np.random.negative_binomial(
+                    gtyper.no_of_successes, gtyper.prob_of_success
+                )
+            else:
+                correct_coverage = np.random.poisson(mean_depth)
+
             incorrect_coverage = np.random.binomial(mean_depth, error_rate)
             if correct_coverage + incorrect_coverage == 0:
                 continue
@@ -64,16 +68,10 @@ class GenotypeConfidenceSimulator:
                 [incorrect_coverage] * allele_length,
                 [correct_coverage] * allele_length,
             ]
-            gtyper = genotyper.Genotyper(
-                mean_depth,
-                error_rate,
-                allele_combination_cov,
-                allele_per_base_cov,
-                allele_groups_dict,
-                call_hets=call_hets,
+            gtyper.run(allele_combination_cov, allele_per_base_cov, allele_groups_dict)
+            logging.debug(
+                f"Simulation:\t{i}\t{correct_coverage}\t{incorrect_coverage}\t{gtyper.genotype_confidence}"
             )
-            gtyper.run()
-            logging.debug(f"Simulation:\t{i}\t{correct_coverage}\t{incorrect_coverage}\t{gtyper.genotype_confidence}")
             confidences.append(round(gtyper.genotype_confidence))
             i += 1
 

--- a/minos/genotyper.py
+++ b/minos/genotyper.py
@@ -3,22 +3,92 @@ import logging
 import math
 import operator
 
-from scipy.stats import poisson
+from scipy.stats import nbinom, poisson
 
 
 class Genotyper:
     def __init__(
         self,
         mean_depth,
+        depth_variance,
         error_rate,
-        allele_combination_cov,
-        allele_per_base_cov,
-        allele_groups_dict,
-        min_cov_more_than_error=None,
-        call_hets=True,
+        call_hets=False,
+        force_poisson=False,
     ):
         self.mean_depth = mean_depth
+        self.depth_variance = depth_variance
         self.error_rate = error_rate
+        self.call_hets = call_hets
+        self.force_poisson = force_poisson
+        self._determine_poisson_or_nbinom()
+        self._set_min_cov_more_than_error()
+        self._init_alleles_and_genotypes()
+        logging.info(
+            f"Genotyper. use_het_model={call_hets}, mean_depth={mean_depth}, depth_variance={depth_variance}, error_rate={error_rate}, using_nbinom={self.use_nbinom}, nbinom_no_of_successes={self.no_of_successes}, nbinom_prob_of_success={self.prob_of_success}, min_cov_more_than_error={self.min_cov_more_than_error}"
+        )
+
+    def _determine_poisson_or_nbinom(self):
+        # We can only use nbinom if variance > depth. Otherwise fall back on
+        # poisson model, which is likely to be worse. Should only happen when
+        # read depth is very low
+        if self.force_poisson:
+            self.use_nbinom = False
+        else:
+            self.use_nbinom = self.depth_variance > self.mean_depth
+
+        if self.use_nbinom:
+            self.no_of_successes = (self.mean_depth ** 2) / (
+                self.depth_variance - self.mean_depth
+            )
+            self.prob_of_success = (
+                1 - (self.depth_variance - self.mean_depth) / self.depth_variance
+            )
+            self.half_no_of_successes = ((0.5 * self.mean_depth) ** 2) / (
+                self.depth_variance - (0.5 * self.mean_depth)
+            )
+            self.half_prob_of_success = (
+                1
+                - (self.depth_variance - (0.5 * self.mean_depth)) / self.depth_variance
+            )
+        else:
+            self.no_of_successes = None
+            self.prob_of_success = None
+            self.half_no_of_successes = None
+            self.half_prob_of_success = None
+
+    def _nbinom_or_poisson_pmf(self, value, half_mean=False):
+        if self.use_nbinom:
+            if half_mean:
+                return nbinom.pmf(
+                    value, self.half_no_of_successes, self.half_prob_of_success
+                )
+            else:
+                return nbinom.pmf(value, self.no_of_successes, self.prob_of_success)
+        else:
+            if half_mean:
+                return poisson.pmf(value, 0.5 * self.mean_depth)
+            else:
+                return poisson.pmf(value, self.mean_depth)
+
+    def _set_min_cov_more_than_error(self):
+        self.min_cov_more_than_error = 0
+        if self.mean_depth == 0:
+            return
+        while self._nbinom_or_poisson_pmf(self.min_cov_more_than_error) <= pow(
+            self.error_rate, self.min_cov_more_than_error
+        ):
+            self.min_cov_more_than_error += 1
+            if self.min_cov_more_than_error >= 1000:
+                raise RuntimeError(
+                    f"Something has likely gone wrong calculating minimum read depth that is more likely to happen than by chance due to read errors. error_rate={self.error_rate}, mean_depth={self.mean_depth}, depth_variance={self.depth_variance}. Cannot continue"
+                )
+
+    def _init_alleles_and_genotypes(
+        self,
+        allele_combination_cov=None,
+        allele_per_base_cov=None,
+        allele_groups_dict=None,
+    ):
         self.allele_combination_cov = allele_combination_cov
         self.allele_per_base_cov = allele_per_base_cov
         self.allele_groups_dict = allele_groups_dict
@@ -28,35 +98,6 @@ class Genotyper:
         self.genotype_confidence = None
         self.singleton_allele_coverages = {}
         self.haploid_allele_coverages = []
-        if min_cov_more_than_error is None:
-            self.min_cov_more_than_error = Genotyper.get_min_cov_to_be_more_likely_than_error(
-                self.mean_depth, self.error_rate
-            )
-        else:
-            self.min_cov_more_than_error = min_cov_more_than_error
-        self.call_hets = call_hets
-        logging.debug(f"Genotyper. mean_depth={mean_depth}, error_rate={error_rate}, allele_combination_cov={allele_combination_cov}, call_hets={call_hets}, min_cov_more_than_error={self.min_cov_more_than_error}")
-
-    @classmethod
-    def get_min_cov_to_be_more_likely_than_error(cls, mean_depth, error_rate):
-        # For each allele, We want to get the number of positions that have read
-        # depth higher than we would expect by chance. Work out the minimum
-        # depth needed once here (code was previously repeatedly calling
-        # poisson.pmf in _non_zeros_from_allele_per_base_cov()). Doing it once
-        # here is about 80 to 90 times faster.
-
-        # If the mean depth is zero, we'll be returning null genotypes with zero
-        # confidence. Doesn't matter what we calculate here.
-        if mean_depth == 0:
-            return 0
-        min_cov = 0
-        while poisson.pmf(min_cov, mean_depth) <= pow(error_rate, min_cov):
-            min_cov += 1
-            if min_cov >= 1000:
-                raise RuntimeError(
-                    f"Something has likely gone wrong calculating minimum read depth that is more likely to happen than by chance due to read errors. error_rate={error_rate}, mean_depth={mean_depth}. Cannot continue"
-                )
-        return min_cov
 
     @classmethod
     def _singleton_alleles_and_coverage(
@@ -86,11 +127,7 @@ class Genotyper:
 
     @classmethod
     def _coverage_of_diploid_alleles(
-        cls,
-        allele1,
-        allele2,
-        allele_combination_cov,
-        allele_groups_dict,
+        cls, allele1, allele2, allele_combination_cov, allele_groups_dict,
     ):
         """
         Collects coverage on each of two alleles.
@@ -116,37 +153,39 @@ class Genotyper:
                 allele2_total_cov += coverage
 
         ## Perform the dispatching in ambiguous equiv classes ##
-        if allele1_total_cov == 0 and allele2_total_cov == 0:  # If both are zero, do equal dispatching
+        if (
+            allele1_total_cov == 0 and allele2_total_cov == 0
+        ):  # If both are zero, do equal dispatching
             allele1_belonging = 0.5
         else:
-            allele1_belonging = allele1_total_cov / (allele1_total_cov + allele2_total_cov)
+            allele1_belonging = allele1_total_cov / (
+                allele1_total_cov + allele2_total_cov
+            )
 
         allele1_total_cov += allele1_belonging * shared_cov
         allele2_total_cov += (1 - allele1_belonging) * shared_cov
         return allele1_total_cov, allele2_total_cov
 
-    @classmethod
     def _log_likelihood_homozygous(
-        cls, mean_depth, allele_depth, total_depth, error_rate, allele_length, non_zeros
+        self, allele_depth, total_depth, allele_length, non_zeros
     ):
         return sum(
             [
-                -mean_depth * (1 + (allele_length - non_zeros) / allele_length),
-                allele_depth * math.log(mean_depth),
+                -self.mean_depth * (1 + (allele_length - non_zeros) / allele_length),
+                allele_depth * math.log(self.mean_depth),
                 -math.lgamma(allele_depth + 1),
-                (total_depth - allele_depth) * math.log(error_rate),
-                non_zeros * math.log(1 - poisson.pmf(0, mean_depth)) / allele_length,
+                (total_depth - allele_depth) * math.log(self.error_rate),
+                non_zeros
+                * math.log(1 - self._nbinom_or_poisson_pmf(0))
+                / allele_length,
             ]
         )
 
-    @classmethod
     def _log_likelihood_heterozygous(
-        cls,
-        mean_depth,
+        self,
         allele_depth1,
         allele_depth2,
         total_depth,
-        error_rate,
         allele_length1,
         allele_length2,
         non_zeros1,
@@ -154,7 +193,7 @@ class Genotyper:
     ):
         return sum(
             [
-                -mean_depth
+                -self.mean_depth
                 * (
                     1
                     + 0.5
@@ -163,12 +202,13 @@ class Genotyper:
                         + (1 - (non_zeros2 / allele_length2))
                     )
                 ),
-                (allele_depth1 + allele_depth2) * math.log(0.5 * mean_depth),
+                (allele_depth1 + allele_depth2) * math.log(0.5 * self.mean_depth),
                 -math.lgamma(allele_depth1 + 1),
                 -math.lgamma(allele_depth2 + 1),
-                (total_depth - allele_depth1 - allele_depth2) * math.log(error_rate),
+                (total_depth - allele_depth1 - allele_depth2)
+                * math.log(self.error_rate),
                 ((non_zeros1 / allele_length1) + (non_zeros2 / allele_length2))
-                * math.log(1 - poisson.pmf(0, 0.5 * mean_depth)),
+                * math.log(1 - self._nbinom_or_poisson_pmf(0, half_mean=True)),
             ]
         )
 
@@ -191,7 +231,9 @@ class Genotyper:
         )
 
         self.haploid_allele_coverages = Genotyper._haploid_allele_coverages(
-            len(self.allele_per_base_cov), self.allele_combination_cov, self.allele_groups_dict
+            len(self.allele_per_base_cov),
+            self.allele_combination_cov,
+            self.allele_groups_dict,
         )
 
         for allele_number, per_base_cov in enumerate(self.allele_per_base_cov):
@@ -199,16 +241,15 @@ class Genotyper:
             non_zeros = non_zeros_per_allele[allele_number]
             allele_depth = self.haploid_allele_coverages[allele_number]
 
-            log_likelihood = Genotyper._log_likelihood_homozygous(
-                self.mean_depth,
-                allele_depth,
-                total_depth,
-                self.error_rate,
-                allele_length,
-                non_zeros,
+            log_likelihood = self._log_likelihood_homozygous(
+                allele_depth, total_depth, allele_length, non_zeros,
             )
-            frac_support = 0 if total_depth == 0 else round(allele_depth / total_depth, 4)
-            self.likelihoods.append(({allele_number, allele_number}, log_likelihood, frac_support))
+            frac_support = (
+                0 if total_depth == 0 else round(allele_depth / total_depth, 4)
+            )
+            self.likelihoods.append(
+                ({allele_number, allele_number}, log_likelihood, frac_support)
+            )
 
         self.singleton_allele_coverages = Genotyper._singleton_alleles_and_coverage(
             self.allele_combination_cov, self.allele_groups_dict
@@ -232,25 +273,33 @@ class Genotyper:
             non_zeros1 = non_zeros_per_allele[allele_number1]
             non_zeros2 = non_zeros_per_allele[allele_number2]
 
-            log_likelihood = Genotyper._log_likelihood_heterozygous(
-                self.mean_depth,
+            log_likelihood = self._log_likelihood_heterozygous(
                 allele1_depth,
                 allele2_depth,
                 total_depth,
-                self.error_rate,
                 allele1_length,
                 allele2_length,
                 non_zeros1,
                 non_zeros2,
             )
-            frac_support = 0 if total_depth == 0 else round((allele1_depth + allele2_depth) / total_depth, 4)
+            frac_support = (
+                0
+                if total_depth == 0
+                else round((allele1_depth + allele2_depth) / total_depth, 4)
+            )
             self.likelihoods.append(
                 (set([allele_number1, allele_number2]), log_likelihood, frac_support)
             )
 
         self.likelihoods.sort(key=operator.itemgetter(1), reverse=True)
 
-    def run(self):
+    def run(self, allele_combination_cov, allele_per_base_cov, allele_groups_dict):
+        self._init_alleles_and_genotypes(
+            allele_combination_cov=allele_combination_cov,
+            allele_per_base_cov=allele_per_base_cov,
+            allele_groups_dict=allele_groups_dict,
+        )
+
         if (
             len(self.allele_combination_cov) == 0
             or Genotyper._total_coverage(self.allele_combination_cov) == 0

--- a/minos/genotyper.py
+++ b/minos/genotyper.py
@@ -1,4 +1,5 @@
 import itertools
+import logging
 import math
 import operator
 
@@ -34,6 +35,7 @@ class Genotyper:
         else:
             self.min_cov_more_than_error = min_cov_more_than_error
         self.call_hets = call_hets
+        logging.debug(f"Genotyper. mean_depth={mean_depth}, error_rate={error_rate}, allele_combination_cov={allele_combination_cov}, call_hets={call_hets}, min_cov_more_than_error={self.min_cov_more_than_error}")
 
     @classmethod
     def get_min_cov_to_be_more_likely_than_error(cls, mean_depth, error_rate):

--- a/minos/gramtools.py
+++ b/minos/gramtools.py
@@ -211,11 +211,7 @@ def load_gramtools_vcf_and_allele_coverage_files(vcf_file, quasimap_dir):
 
 
 def update_vcf_record_using_gramtools_allele_depths(
-    vcf_record,
-    gtyper,
-    allele_combination_cov,
-    allele_per_base_cov,
-    allele_groups_dict,
+    vcf_record, gtyper, allele_combination_cov, allele_per_base_cov, allele_groups_dict,
 ):
     """allele_depths should be a dict of allele -> coverage.
     The REF allele must also be in the dict.

--- a/minos/gramtools.py
+++ b/minos/gramtools.py
@@ -212,13 +212,10 @@ def load_gramtools_vcf_and_allele_coverage_files(vcf_file, quasimap_dir):
 
 def update_vcf_record_using_gramtools_allele_depths(
     vcf_record,
+    gtyper,
     allele_combination_cov,
     allele_per_base_cov,
     allele_groups_dict,
-    mean_depth,
-    read_error_rate,
-    min_cov_more_than_error=None,
-    call_hets=True,
 ):
     """allele_depths should be a dict of allele -> coverage.
     The REF allele must also be in the dict.
@@ -226,16 +223,7 @@ def update_vcf_record_using_gramtools_allele_depths(
     This also changes all columns from QUAL onwards.
     Returns a VcfRecord the same as vcf_record, but with all zero
     coverage alleles removed, and GT and COV fixed accordingly"""
-    gtyper = genotyper.Genotyper(
-        mean_depth,
-        read_error_rate,
-        allele_combination_cov,
-        allele_per_base_cov,
-        allele_groups_dict,
-        min_cov_more_than_error=min_cov_more_than_error,
-        call_hets=call_hets,
-    )
-    gtyper.run()
+    gtyper.run(allele_combination_cov, allele_per_base_cov, allele_groups_dict)
     genotype_indexes = set()
 
     if "." in gtyper.genotype:
@@ -265,7 +253,7 @@ def update_vcf_record_using_gramtools_allele_depths(
     vcf_record.FORMAT.clear()
     dp = sum(allele_combination_cov.values())
     vcf_record.set_format_key_value("DP", str(dp))
-    dpf = 0 if dp == 0 else str(round(dp / mean_depth, 4))
+    dpf = 0 if dp == 0 else str(round(dp / gtyper.mean_depth, 4))
     vcf_record.set_format_key_value("DPF", str(dpf))
     vcf_record.set_format_key_value("GT", genotype)
     vcf_record.set_format_key_value("COV", cov_string)
@@ -315,6 +303,7 @@ def update_vcf_record_using_gramtools_allele_depths(
 
 def write_vcf_annotated_using_coverage_from_gramtools(
     mean_depth,
+    depth_variance,
     vcf_records,
     all_allele_coverage,
     allele_groups,
@@ -324,7 +313,7 @@ def write_vcf_annotated_using_coverage_from_gramtools(
     max_read_length=None,
     filtered_outfile=None,
     ref_seq_lengths=None,
-    call_hets=True,
+    call_hets=False,
 ):
     """mean_depth, vcf_records, all_allele_coverage, allele_groups should be those
     returned by load_gramtools_vcf_and_allele_coverage_files().
@@ -368,8 +357,8 @@ def write_vcf_annotated_using_coverage_from_gramtools(
         )
     )
 
-    min_cov_more_than_error = genotyper.Genotyper.get_min_cov_to_be_more_likely_than_error(
-        mean_depth, read_error_rate
+    gtyper = genotyper.Genotyper(
+        mean_depth, depth_variance, read_error_rate, call_hets=call_hets,
     )
 
     if filtered_outfile is not None:
@@ -383,13 +372,10 @@ def write_vcf_annotated_using_coverage_from_gramtools(
             logging.debug("Genotyping: " + str(vcf_records[i]))
             filtered_record = update_vcf_record_using_gramtools_allele_depths(
                 vcf_records[i],
+                gtyper,
                 all_allele_coverage[i][0],
                 all_allele_coverage[i][1],
                 allele_groups,
-                mean_depth,
-                read_error_rate,
-                min_cov_more_than_error=min_cov_more_than_error,
-                call_hets=call_hets,
             )
             print(vcf_records[i], file=f)
             if filtered_outfile is not None:

--- a/minos/tasks/adjudicate.py
+++ b/minos/tasks/adjudicate.py
@@ -23,5 +23,6 @@ def run(options):
         filter_min_gcp=options.filter_min_gcp,
         filter_min_frs=options.filter_min_frs,
         call_hets=options.include_het_calls,
+        debug=options.debug,
     )
     adj.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 cluster_vcf_records >= 0.11.1
+matplotlib
 pyfastaq >= 3.14.0
 pysam >= 0.12
 scipy >= 1.0.0
+seaborn

--- a/tests/adjudicator_test.py
+++ b/tests/adjudicator_test.py
@@ -1,226 +1,209 @@
 import filecmp
 import shutil
 import os
-import unittest
+import pytest
 
-from minos import adjudicator
+from minos import adjudicator, genotype_confidence_simulator
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(this_dir, "data", "adjudicator")
 
 
-class TestAdjudicator(unittest.TestCase):
-    def test_get_gramtools_kmer_size(self):
-        """test _get_gramtools_kmer_size"""
-        build_dir = os.path.join(data_dir, "get_gramtools_kmer_size.build")
-        self.assertEqual(
-            42, adjudicator.Adjudicator._get_gramtools_kmer_size(build_dir, None)
-        )
-        self.assertEqual(
-            42, adjudicator.Adjudicator._get_gramtools_kmer_size(build_dir, 20)
-        )
-        self.assertEqual(20, adjudicator.Adjudicator._get_gramtools_kmer_size(None, 20))
-        self.assertEqual(
-            10, adjudicator.Adjudicator._get_gramtools_kmer_size(None, None)
-        )
+def test_get_gramtools_kmer_size():
+    """test _get_gramtools_kmer_size"""
+    build_dir = os.path.join(data_dir, "get_gramtools_kmer_size.build")
+    assert adjudicator.Adjudicator._get_gramtools_kmer_size(build_dir, None) == 42
+    assert adjudicator.Adjudicator._get_gramtools_kmer_size(build_dir, 20) == 42
+    assert adjudicator.Adjudicator._get_gramtools_kmer_size(None, 20) == 20
+    assert adjudicator.Adjudicator._get_gramtools_kmer_size(None, None) == 10
 
-    def test_run_clean_is_false(self):
-        """test run when not cleaning up files afterwards"""
-        # We're just testing that it doesn't crash.
-        # Check the output files exist, but not their contents.
-        # First run using splitting of VCF file.
-        # Then run without splitting.
-        outdir = "tmp.adjudicator.noclean.out"
-        if os.path.exists(outdir):
-            shutil.rmtree(outdir)
-        ref_fasta = os.path.join(data_dir, "run.ref.fa")
-        reads_file = os.path.join(data_dir, "run.bwa.bam")
-        vcf_files = [
-            os.path.join(data_dir, x) for x in ["run.calls.1.vcf", "run.calls.2.vcf"]
-        ]
-        adj = adjudicator.Adjudicator(
-            outdir,
-            ref_fasta,
-            [reads_file],
-            vcf_files,
-            variants_per_split=3,
-            clean=False,
-            gramtools_kmer_size=5,
-            genotype_simulation_iterations=1000,
-        )
-        adj.run()
-        self.assertTrue(os.path.exists(outdir))
-        self.assertTrue(os.path.exists(adj.log_file))
-        self.assertTrue(os.path.exists(adj.final_vcf))
-        self.assertTrue(os.path.exists(adj.clustered_vcf))
 
-        # Clean up and then run without splitting
+def test_run_clean_is_false():
+    """test run when not cleaning up files afterwards"""
+    # We're just testing that it doesn't crash.
+    # Check the output files exist, but not their contents.
+    # First run using splitting of VCF file.
+    # Then run without splitting.
+    outdir = "tmp.adjudicator.noclean.out"
+    if os.path.exists(outdir):
         shutil.rmtree(outdir)
-        adj = adjudicator.Adjudicator(
-            outdir,
-            ref_fasta,
-            [reads_file],
-            vcf_files,
-            clean=False,
-            gramtools_kmer_size=5,
-            genotype_simulation_iterations=1000,
-        )
-        adj.run()
-        self.assertTrue(os.path.exists(outdir))
-        self.assertTrue(os.path.exists(adj.log_file))
-        self.assertTrue(os.path.exists(adj.final_vcf))
-        self.assertTrue(os.path.exists(adj.gramtools_build_dir))
-        self.assertTrue(os.path.exists(adj.gramtools_quasimap_dir))
-        self.assertTrue(os.path.exists(adj.clustered_vcf))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".data.tsv"))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".dp_hist.pdf"))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".gt_conf_dp_scatter.pdf"))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".gt_conf_hist.pdf"))
+    ref_fasta = os.path.join(data_dir, "run.ref.fa")
+    reads_file = os.path.join(data_dir, "run.bwa.bam")
+    vcf_files = [
+        os.path.join(data_dir, x) for x in ["run.calls.1.vcf", "run.calls.2.vcf"]
+    ]
+    adj = adjudicator.Adjudicator(
+        outdir,
+        ref_fasta,
+        [reads_file],
+        vcf_files,
+        variants_per_split=3,
+        clean=False,
+        gramtools_kmer_size=5,
+        genotype_simulation_iterations=1000,
+    )
+    adj.run()
+    assert os.path.exists(outdir)
+    assert os.path.exists(adj.log_file)
+    assert os.path.exists(adj.final_vcf)
+    assert os.path.exists(adj.clustered_vcf)
 
-        # Now we've run the adjudicator, we have a gramtools
-        # build directory. Rerun, but this time use the build
-        # directory, so we test the gramtools_build_dir option
-        outdir2 = "tmp.adjudicator.out.2"
-        gramtools_build_dir = adj.gramtools_build_dir
-        if os.path.exists(outdir2):
-            shutil.rmtree(outdir2)
-        ref_fasta = os.path.join(data_dir, "run.ref.fa")
-        reads_file = os.path.join(data_dir, "run.bwa.bam")
-        # When gramtools build dir supplied, the Adjudicator assumes
-        # one clsutered VCF file that matches the gramtools build run.
-        # This is the clustered VCF made by the Adjudicator, so we
-        # use that instead of the list of original VCF files
-        vcf_files = [adj.clustered_vcf]
-        adj = adjudicator.Adjudicator(
-            outdir2,
-            ref_fasta,
-            [reads_file],
-            vcf_files,
-            gramtools_build_dir=gramtools_build_dir,
-            clean=False,
-            gramtools_kmer_size=5,
-            genotype_simulation_iterations=1000,
-        )
-        adj.run()
-        self.assertTrue(os.path.exists(outdir2))
-        self.assertTrue(os.path.exists(adj.log_file))
-        self.assertTrue(os.path.exists(adj.final_vcf))
-        self.assertTrue(os.path.exists(adj.gramtools_build_dir))
-        self.assertTrue(os.path.exists(adj.gramtools_quasimap_dir))
-        self.assertTrue(os.path.exists(adj.clustered_vcf))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".data.tsv"))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".dp_hist.pdf"))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".gt_conf_dp_scatter.pdf"))
-        #self.assertTrue(os.path.exists(adj.plots_prefix + ".gt_conf_hist.pdf"))
-        self.assertFalse(os.path.exists(os.path.join(outdir2, "gramtools.build")))
-        shutil.rmtree(outdir)
+    # Clean up and then run without splitting
+    shutil.rmtree(outdir)
+    adj = adjudicator.Adjudicator(
+        outdir,
+        ref_fasta,
+        [reads_file],
+        vcf_files,
+        clean=False,
+        gramtools_kmer_size=5,
+        genotype_simulation_iterations=1000,
+    )
+    adj.run()
+    assert os.path.exists(outdir)
+    assert os.path.exists(adj.log_file)
+    assert os.path.exists(adj.final_vcf)
+    assert os.path.exists(adj.gramtools_build_dir)
+    assert os.path.exists(adj.gramtools_quasimap_dir)
+    assert os.path.exists(adj.clustered_vcf)
+
+    # Now we've run the adjudicator, we have a gramtools
+    # build directory. Rerun, but this time use the build
+    # directory, so we test the gramtools_build_dir option
+    outdir2 = "tmp.adjudicator.out.2"
+    gramtools_build_dir = adj.gramtools_build_dir
+    if os.path.exists(outdir2):
         shutil.rmtree(outdir2)
+    ref_fasta = os.path.join(data_dir, "run.ref.fa")
+    reads_file = os.path.join(data_dir, "run.bwa.bam")
+    # When gramtools build dir supplied, the Adjudicator assumes
+    # one clsutered VCF file that matches the gramtools build run.
+    # This is the clustered VCF made by the Adjudicator, so we
+    # use that instead of the list of original VCF files
+    vcf_files = [adj.clustered_vcf]
+    adj = adjudicator.Adjudicator(
+        outdir2,
+        ref_fasta,
+        [reads_file],
+        vcf_files,
+        gramtools_build_dir=gramtools_build_dir,
+        clean=False,
+        gramtools_kmer_size=5,
+        genotype_simulation_iterations=1000,
+    )
+    adj.run()
+    assert os.path.exists(outdir2)
+    assert os.path.exists(adj.log_file)
+    assert os.path.exists(adj.final_vcf)
+    assert os.path.exists(adj.gramtools_build_dir)
+    assert os.path.exists(adj.gramtools_quasimap_dir)
+    assert os.path.exists(adj.clustered_vcf)
+    assert not os.path.exists(os.path.join(outdir2, "gramtools.build"))
+    shutil.rmtree(outdir)
+    shutil.rmtree(outdir2)
 
-    def test_run_clean_is_true(self):
-        """test run when we do clean files afterwards"""
-        # We're just testing that it doesn't crash.
-        # Check the output files exist, but not their contents.
-        # First run using splitting of VCF file.
-        # Then run without splitting.
-        outdir = "tmp.adjudicator.clean.out"
-        if os.path.exists(outdir):
-            shutil.rmtree(outdir)
-        ref_fasta = os.path.join(data_dir, "run.ref.fa")
-        reads_file = os.path.join(data_dir, "run.bwa.bam")
-        vcf_files = [
-            os.path.join(data_dir, x) for x in ["run.calls.1.vcf", "run.calls.2.vcf"]
-        ]
-        adj = adjudicator.Adjudicator(
-            outdir,
-            ref_fasta,
-            [reads_file],
-            vcf_files,
-            clean=True,
-            gramtools_kmer_size=5,
-            genotype_simulation_iterations=1000,
-        )
-        adj.run()
-        self.assertTrue(os.path.exists(outdir))
-        self.assertTrue(os.path.exists(os.path.join(outdir, "final.vcf")))
+
+def test_run_clean_is_true():
+    """test run when we do clean files afterwards"""
+    # We're just testing that it doesn't crash.
+    # Check the output files exist, but not their contents.
+    # First run using splitting of VCF file.
+    # Then run without splitting.
+    outdir = "tmp.adjudicator.clean.out"
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    ref_fasta = os.path.join(data_dir, "run.ref.fa")
+    reads_file = os.path.join(data_dir, "run.bwa.bam")
+    vcf_files = [
+        os.path.join(data_dir, x) for x in ["run.calls.1.vcf", "run.calls.2.vcf"]
+    ]
+    adj = adjudicator.Adjudicator(
+        outdir,
+        ref_fasta,
+        [reads_file],
+        vcf_files,
+        clean=True,
+        gramtools_kmer_size=5,
+        genotype_simulation_iterations=1000,
+    )
+    adj.run()
+    assert os.path.exists(outdir)
+    assert os.path.exists(os.path.join(outdir, "final.vcf"))
+    shutil.rmtree(outdir)
+
+
+def test_run_empty_vcf_input_files():
+    """test run when input files have no variants"""
+    outdir = "tmp.adjudicator.out"
+    if os.path.exists(outdir):
         shutil.rmtree(outdir)
 
-    def test_run_empty_vcf_input_files(self):
-        """test run when input files have no variants"""
-        outdir = "tmp.adjudicator.out"
-        if os.path.exists(outdir):
-            shutil.rmtree(outdir)
-
-        ref_fasta = os.path.join(data_dir, "run.ref.fa")
-        reads_file = os.path.join(data_dir, "run.bwa.bam")
-        vcf_files = [
-            os.path.join(data_dir, x)
-            for x in ["run.calls.empty.1.vcf", "run.calls.empty.2.vcf"]
-        ]
-        adj = adjudicator.Adjudicator(
-            outdir,
-            ref_fasta,
-            [reads_file],
-            vcf_files,
-            clean=False,
-            gramtools_kmer_size=5,
-            genotype_simulation_iterations=1000,
-        )
-        with self.assertRaises(Exception):
-            adj.run()
-        self.assertTrue(os.path.exists(outdir))
-        self.assertTrue(os.path.exists(adj.log_file))
-        self.assertFalse(os.path.exists(adj.final_vcf))
-        self.assertFalse(os.path.exists(adj.gramtools_build_dir))
-        self.assertFalse(os.path.exists(adj.gramtools_quasimap_dir))
-        #self.assertFalse(os.path.exists(adj.plots_prefix + ".data.tsv"))
-        #self.assertFalse(os.path.exists(adj.plots_prefix + ".dp_hist.pdf"))
-        #self.assertFalse(os.path.exists(adj.plots_prefix + ".gt_conf_dp_scatter.pdf"))
-        #self.assertFalse(os.path.exists(adj.plots_prefix + ".gt_conf_hist.pdf"))
-        self.assertTrue(os.path.exists(adj.clustered_vcf))
-        shutil.rmtree(outdir)
-
-    def test_add_gt_conf_percentile_and_filters_to_vcf_file(self):
-        """test _add_gt_conf_percentile_and_filters_to_vcf_file"""
-        original_file = os.path.join(
-            data_dir, "add_gt_conf_percentile_to_vcf_file.in.vcf"
-        )
-        tmp_file = "tmp.adjudicator.add_gt_conf_percentile_to_vcf_file.vcf"
-        expect_file = os.path.join(
-            data_dir, "add_gt_conf_percentile_to_vcf_file.expect.vcf"
-        )
-        shutil.copyfile(original_file, tmp_file)
-        error_rate = 0.00026045894282438386
-        adjudicator.Adjudicator._add_gt_conf_percentile_and_filters_to_vcf_file(
-            tmp_file, 60, 100, error_rate, iterations=1000, min_dp=2, min_gcp=2.5, min_frs=0.9
-        )
-        self.assertTrue(filecmp.cmp(tmp_file, expect_file, shallow=False))
-        os.unlink(tmp_file)
-
-    def test_0MeanDepth_stillRuns(self):
-        """
-        When mean depth is 0, we can get math errors: math.log(0) in genotype likelihood computation,
-        and division by 0 in genotype confidence simulation.
-
-        Note the former only actually occurs if there is a variant site with non-zero coverage;
-        in this case, mean depth can get set to 0 due to rounding imprecision. This is tested in genotyper unit tests.
-        """
-
-        outdir = "tmp.adjudicator.out"
-        if os.path.exists(outdir):
-            shutil.rmtree(outdir)
-        ref_fasta = os.path.join(data_dir, "run.ref.fa")
-        reads_file = os.path.join(data_dir, "no_map_reads.fastq")
-        vcf_files = [os.path.join(data_dir, "run.calls.1.vcf")]
-
-        adj = adjudicator.Adjudicator(
-            outdir,
-            ref_fasta,
-            [reads_file],
-            vcf_files,
-            clean=False,
-            gramtools_kmer_size=5,
-        )
+    ref_fasta = os.path.join(data_dir, "run.ref.fa")
+    reads_file = os.path.join(data_dir, "run.bwa.bam")
+    vcf_files = [
+        os.path.join(data_dir, x)
+        for x in ["run.calls.empty.1.vcf", "run.calls.empty.2.vcf"]
+    ]
+    adj = adjudicator.Adjudicator(
+        outdir,
+        ref_fasta,
+        [reads_file],
+        vcf_files,
+        clean=False,
+        gramtools_kmer_size=5,
+        genotype_simulation_iterations=1000,
+    )
+    with pytest.raises(Exception):
         adj.run()
-        # Make sure the coverage is 0
-        self.assertEqual(adj.mean_depths[0], 0)
-        # And also the test passes if it raises no math related errors.
+    assert os.path.exists(outdir)
+    assert os.path.exists(adj.log_file)
+    assert not os.path.exists(adj.final_vcf)
+    assert not os.path.exists(adj.gramtools_build_dir)
+    assert not os.path.exists(adj.gramtools_quasimap_dir)
+    assert os.path.exists(adj.clustered_vcf)
+    shutil.rmtree(outdir)
+
+
+def test_add_gt_conf_percentile_and_filters_to_vcf_file():
+    """test _add_gt_conf_percentile_and_filters_to_vcf_file"""
+    original_file = os.path.join(data_dir, "add_gt_conf_percentile_to_vcf_file.in.vcf")
+    tmp_file = "tmp.adjudicator.add_gt_conf_percentile_to_vcf_file.vcf"
+    expect_file = os.path.join(
+        data_dir, "add_gt_conf_percentile_to_vcf_file.expect.vcf"
+    )
+    shutil.copyfile(original_file, tmp_file)
+    error_rate = 0.00026045894282438386
+    simulations = genotype_confidence_simulator.GenotypeConfidenceSimulator(
+        60, 100, error_rate, iterations=1000, call_hets=True,
+    )
+    simulations.run_simulations()
+    adjudicator.Adjudicator._add_gt_conf_percentile_and_filters_to_vcf_file(
+        tmp_file, simulations, min_dp=2, min_gcp=2.5, min_frs=0.9
+    )
+    assert filecmp.cmp(tmp_file, expect_file, shallow=False)
+    os.unlink(tmp_file)
+
+
+def test_0MeanDepth_stillRuns():
+    """
+    When mean depth is 0, we can get math errors: math.log(0) in genotype likelihood computation,
+    and division by 0 in genotype confidence simulation.
+
+    Note the former only actually occurs if there is a variant site with non-zero coverage;
+    in this case, mean depth can get set to 0 due to rounding imprecision. This is tested in genotyper unit tests.
+    """
+
+    outdir = "tmp.adjudicator.out"
+    if os.path.exists(outdir):
+        shutil.rmtree(outdir)
+    ref_fasta = os.path.join(data_dir, "run.ref.fa")
+    reads_file = os.path.join(data_dir, "no_map_reads.fastq")
+    vcf_files = [os.path.join(data_dir, "run.calls.1.vcf")]
+
+    adj = adjudicator.Adjudicator(
+        outdir, ref_fasta, [reads_file], vcf_files, clean=False, gramtools_kmer_size=5,
+    )
+    adj.run()
+    # Make sure the coverage is 0
+    assert adj.mean_depths[0] == 0
+    # And also the test passes if it raises no math related errors.

--- a/tests/adjudicator_test.py
+++ b/tests/adjudicator_test.py
@@ -207,3 +207,4 @@ def test_0MeanDepth_stillRuns():
     # Make sure the coverage is 0
     assert adj.mean_depths[0] == 0
     # And also the test passes if it raises no math related errors.
+    shutil.rmtree(outdir)

--- a/tests/data/adjudicator/add_gt_conf_percentile_to_vcf_file.expect.vcf
+++ b/tests/data/adjudicator/add_gt_conf_percentile_to_vcf_file.expect.vcf
@@ -6,10 +6,10 @@
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
 ##FORMAT=<ID=DP,Number=1,Type=Integer,Description="total kmer depth from gramtools",Source="minos">
 ##FORMAT=<ID=GT_CONF,Number=1,Type=Float,Description="Genotype confidence. Difference in log likelihood of most likely and next most likely genotype">
-##FILTER=<ID=MIN_GCP,Description="Minimum GT_CONF_PERCENTILE of 2.5">
-##FILTER=<ID=MIN_DP,Description="Minimum DP of 2">
-##FILTER=<ID=MIN_FRS,Description="Minimum FRS of 0.9">
 ##FORMAT=<ID=GT_CONF_PERCENTILE,Number=1,Type=Float,Description="Percentile of GT_CONF">
+##FILTER=<ID=MIN_FRS,Description="Minimum FRS of 0.9">
+##FILTER=<ID=MIN_DP,Description="Minimum DP of 2">
+##FILTER=<ID=MIN_GCP,Description="Minimum GT_CONF_PERCENTILE of 2.5">
 ##minos_max_read_length=200
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_name
 ref	100	.	T	G	.	PASS	.	GT:DP:COV:FRS:GT_CONF:GT_CONF_PERCENTILE	1/1:63:0,63:0.9:609.67:52.86

--- a/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf
+++ b/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf
@@ -1,6 +1,6 @@
 ##fileformat=VCFv4.2
 ##source=minos, version 0.10.0
-##fileDate=2020-03-10
+##fileDate=2020-06-17
 ##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
 ##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
@@ -11,6 +11,6 @@
 ##contig=<ID=ref,length=10000>
 ##minos_max_read_length=200
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_42
-ref	1	.	G	T	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	1/1:11:1.5714:0,10:1.0:11.15
-ref	2	.	A	C,TA,G	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	2/3:10:1.4286:1,0,3,5:0.9:18.2
+ref	1	.	G	T	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	1/1:11:1.5714:0,10:1.0:11.6
+ref	2	.	A	C,TA,G	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	2/3:10:1.4286:1,0,3,5:0.9:17.68
 ref	42	.	A	G	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	./.:0:0:0,0:.:0.0

--- a/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf.filter.vcf
+++ b/tests/data/gramtools/write_vcf_annotated_using_coverage_from_gramtools.out.vcf.filter.vcf
@@ -1,6 +1,6 @@
 ##fileformat=VCFv4.2
 ##source=minos, version 0.10.0
-##fileDate=2020-03-10
+##fileDate=2020-06-17
 ##FORMAT=<ID=COV,Number=R,Type=Integer,Description="Number of reads on ref and alt alleles">
 ##FORMAT=<ID=FRS,Number=1,Type=Float,Description="Fraction of reads that support the genotype call">
 ##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
@@ -11,6 +11,6 @@
 ##contig=<ID=ref,length=10000>
 ##minos_max_read_length=200
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample_42
-ref	1	.	G	T	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	1/1:11:1.5714:0,10:1.0:11.15
-ref	2	.	A	TA,G	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	1/2:10:1.4286:1,3,5:0.9:18.2
+ref	1	.	G	T	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	1/1:11:1.5714:0,10:1.0:11.6
+ref	2	.	A	TA,G	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	1/2:10:1.4286:1,3,5:0.9:17.68
 ref	42	.	A	G	.	.	.	GT:DP:DPF:COV:FRS:GT_CONF	./.:0:0:0,0:.:0.0

--- a/tests/genotype_confidence_simulator_test.py
+++ b/tests/genotype_confidence_simulator_test.py
@@ -1,5 +1,5 @@
 import os
-import unittest
+import pytest
 
 from minos import genotype_confidence_simulator
 
@@ -7,122 +7,120 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(this_dir, "data", "genotype_confidence_simulator")
 
 
-class TestGenotypeConfidenceSimulator(unittest.TestCase):
-    def test_simulate_confidence_scores(self):
-        """test _simulate_confidence_scores"""
-        got = genotype_confidence_simulator.GenotypeConfidenceSimulator._simulate_confidence_scores(
-            50, 300, 0.1, iterations=5
-        )
-        expected = [26, 31, 37, 46, 51]
-        self.assertEqual(expected, got)
+def test_simulate_confidence_scores():
+    """test _simulate_confidence_scores"""
+    got = genotype_confidence_simulator.GenotypeConfidenceSimulator._simulate_confidence_scores(
+        50, 300, 0.1, iterations=5
+    )
+    expected = [99, 114, 143, 200, 215]
+    assert got == expected
 
-        #  Since the genotype confidence normalises by length, we shpuld get the same
-        # results with allele lengths 1 and 2.
-        got = genotype_confidence_simulator.GenotypeConfidenceSimulator._simulate_confidence_scores(
-            50, 300, 0.1, iterations=5, allele_length=2
-        )
-        expected = [26, 31, 37, 46, 51]
-        self.assertEqual(expected, got)
+    #  Since the genotype confidence normalises by length, we shpuld get the same
+    # results with allele lengths 1 and 2.
+    got = genotype_confidence_simulator.GenotypeConfidenceSimulator._simulate_confidence_scores(
+        50, 300, 0.1, iterations=5, allele_length=2
+    )
+    expected = [99, 114, 143, 200, 215]
+    assert got == expected
 
-    def test_make_conf_to_percentile_dict(self):
-        """test _make_conf_to_percentile_dict"""
-        confidence_scores = [1, 1, 2, 3, 4, 4, 4, 5, 6, 8]
-        got = genotype_confidence_simulator.GenotypeConfidenceSimulator._make_conf_to_percentile_dict(
-            confidence_scores
-        )
-        expected = {1: 15, 2: 30, 3: 40, 4: 50, 5: 80, 6: 90, 8: 100}
-        self.assertTrue(expected, got)
 
-    def test_run_simulations_and_get_percentile_allele_length_1(self):
-        """test run_simulations and get_percentile"""
-        simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
-            50, 300, 0.1, iterations=5
-        )
-        simulator.run_simulations()
-        expected_confidence_scores_percentiles = {
-            26: 20.0,
-            31: 40.0,
-            37: 60.0,
-            46: 80.0,
-            51: 100.0,
-        }
-        self.assertEqual(
-            expected_confidence_scores_percentiles,
-            simulator.confidence_scores_percentiles,
-        )
-        self.assertEqual(20.00, simulator.get_percentile(26))
-        self.assertEqual(40.00, simulator.get_percentile(31))
-        # Try getting numbers that are not in the dict and will have to be inferred
-        self.assertEqual(28.00, simulator.get_percentile(28))
-        self.assertEqual(84.00, simulator.get_percentile(47))
-        self.assertEqual(88.00, simulator.get_percentile(48))
-        # Try values outside the range of what we already have
-        self.assertEqual(0.00, simulator.get_percentile(25))
-        self.assertEqual(0.00, simulator.get_percentile(24))
-        self.assertEqual(100.00, simulator.get_percentile(51))
-        self.assertEqual(100.00, simulator.get_percentile(52))
+def test_make_conf_to_percentile_dict():
+    """test _make_conf_to_percentile_dict"""
+    confidence_scores = [1, 1, 2, 3, 4, 4, 4, 5, 6, 8]
+    got = genotype_confidence_simulator.GenotypeConfidenceSimulator._make_conf_to_percentile_dict(
+        confidence_scores
+    )
+    expected = {1: 15, 2: 30, 3: 40, 4: 60, 5: 80, 6: 90, 8: 100}
+    assert got == expected
 
-    def test_run_simulations_and_get_percentile_allele_length_1_no_het_calls(self):
-        """test run_simulations and get_percentile with no het calls"""
-        simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
-            50, 300, 0.1, iterations=5, call_hets=False,
-        )
-        simulator.run_simulations()
-        expected_confidence_scores_percentiles = {
-            149: 20.0, 164: 40.0, 193: 60.0, 200: 80.0, 215: 100.0,
-        }
-        self.assertEqual(
-            expected_confidence_scores_percentiles,
-            simulator.confidence_scores_percentiles,
-        )
-        self.assertEqual(80.00, simulator.get_percentile(200))
 
-    def test_run_simulations_and_get_percentile_allele_length_2(self):
-        """test run_simulations and get_percentile"""
-        simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
-            50, 300, 0.1, allele_length=2, iterations=5
-        )
-        simulator.run_simulations()
-        expected_confidence_scores_percentiles = {
-            26: 20.0,
-            31: 40.0,
-            37: 60.0,
-            46: 80.0,
-            51: 100.0,
-        }
-        self.assertEqual(
-            expected_confidence_scores_percentiles,
-            simulator.confidence_scores_percentiles,
-        )
-        self.assertEqual(20.00, simulator.get_percentile(26))
-        self.assertEqual(40.00, simulator.get_percentile(31))
-        # Try getting numbers that are not in the dict and will have to be inferred
-        self.assertEqual(28.00, simulator.get_percentile(28))
-        self.assertEqual(84.00, simulator.get_percentile(47))
-        self.assertEqual(88.00, simulator.get_percentile(48))
-        # Try values outside the range of what we already have
-        self.assertEqual(0.00, simulator.get_percentile(25))
-        self.assertEqual(0.00, simulator.get_percentile(24))
-        self.assertEqual(100.00, simulator.get_percentile(51))
-        self.assertEqual(100.00, simulator.get_percentile(52))
+def test_run_simulations_and_get_percentile_allele_length_1():
+    """test run_simulations and get_percentile"""
+    simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
+        50, 300, 0.01, iterations=5, call_hets=True
+    )
+    simulator.run_simulations()
+    expected_confidence_scores_percentiles = {
+        55: 20.0,
+        256: 40.0,
+        285: 60.0,
+        337: 80.0,
+        368: 100.0,
+    }
+    assert (
+        simulator.confidence_scores_percentiles
+        == expected_confidence_scores_percentiles
+    )
+    assert simulator.get_percentile(55) == 20.00
+    assert simulator.get_percentile(256) == 40.00
+    # Try getting number that is not in the dict and will have to be inferred
+    assert simulator.get_percentile(150) == 29.45
+    # Try values outside the range of what we already have
+    simulator.get_percentile(53) == 0.00
+    simulator.get_percentile(52) == 0.00
+    simulator.get_percentile(369) == 100.00
+    simulator.get_percentile(370) == 100.00
 
-    def test_simulations(self):
-        """test simulations"""
-        mean_depth = 50
-        error_rate = 0.1
-        depth_variance = 300
-        allele_lengths = [1, 2, 10]
-        simulations = genotype_confidence_simulator.Simulations(
-            mean_depth, depth_variance, error_rate, allele_lengths=allele_lengths
-        )
-        self.assertEqual(allele_lengths, sorted(list(simulations.sims.keys())))
-        self.assertEqual(
-            simulations.sims[1].get_percentile(40), simulations.get_percentile(1, 40)
-        )
-        self.assertEqual(
-            simulations.sims[2].get_percentile(40), simulations.get_percentile(2, 40)
-        )
-        # Check we get nearest allele length, when asking for an allele length that wasn't simulated
-        self.assertEqual(
-            simulations.sims[2].get_percentile(40), simulations.get_percentile(3, 40)
-        )
+
+def test_run_simulations_and_get_percentile_allele_length_1_no_het_calls():
+    """test run_simulations and get_percentile with no het calls"""
+    simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
+        50, 300, 0.1, iterations=5, call_hets=False,
+    )
+    simulator.run_simulations()
+    expected_confidence_scores_percentiles = {
+        99: 20.0,
+        114: 40.0,
+        143: 60.0,
+        200: 80.0,
+        215: 100.0,
+    }
+    assert (
+        simulator.confidence_scores_percentiles
+        == expected_confidence_scores_percentiles
+    )
+    assert simulator.get_percentile(200) == 80.00
+
+
+def test_run_simulations_and_get_percentile_allele_length_2():
+    """test run_simulations and get_percentile"""
+    simulator = genotype_confidence_simulator.GenotypeConfidenceSimulator(
+        50, 300, 0.01, allele_length=2, iterations=5, call_hets=True,
+    )
+    simulator.run_simulations()
+    expected_confidence_scores_percentiles = {
+        55: 20.0,
+        256: 40.0,
+        285: 60.0,
+        337: 80.0,
+        368: 100.0,
+    }
+    assert (
+        simulator.confidence_scores_percentiles
+        == expected_confidence_scores_percentiles
+    )
+    assert simulator.get_percentile(55) == 20.00
+    assert simulator.get_percentile(256) == 40.00
+    # Try getting number that is not in the dict and will have to be inferred
+    assert simulator.get_percentile(150) == 29.45
+    # Try values outside the range of what we already have
+    simulator.get_percentile(53) == 0.00
+    simulator.get_percentile(52) == 0.00
+    simulator.get_percentile(369) == 100.00
+    simulator.get_percentile(370) == 100.00
+
+
+def test_simulations():
+    """test simulations"""
+    mean_depth = 50
+    error_rate = 0.1
+    depth_variance = 300
+    allele_lengths = [1, 2, 10]
+    simulations = genotype_confidence_simulator.Simulations(
+        mean_depth, depth_variance, error_rate, allele_lengths=allele_lengths
+    )
+    assert sorted(list(simulations.sims.keys())) == allele_lengths
+    assert simulations.get_percentile(1, 40) == simulations.sims[1].get_percentile(40)
+    assert simulations.get_percentile(2, 40) == simulations.sims[2].get_percentile(40)
+    # Check we get nearest allele length, when asking for an allele length that wasn't simulated
+    assert simulations.get_percentile(3, 40) == simulations.sims[2].get_percentile(40)

--- a/tests/genotyper_test.py
+++ b/tests/genotyper_test.py
@@ -1,5 +1,5 @@
 import os
-import unittest
+import pytest
 
 from minos import genotyper
 
@@ -7,248 +7,259 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(this_dir, "data", "genotyper")
 
 
-class TestGenotyper(unittest.TestCase):
-    def test_get_min_cov_to_be_more_likely_than_error(self):
-        """test get_min_cov_to_be_more_likely_than_error"""
-        self.assertEqual(
-            1, genotyper.Genotyper.get_min_cov_to_be_more_likely_than_error(10, 0.0001)
-        )
-        self.assertEqual(
-            2, genotyper.Genotyper.get_min_cov_to_be_more_likely_than_error(10, 0.001)
-        )
-        self.assertEqual(
-            10, genotyper.Genotyper.get_min_cov_to_be_more_likely_than_error(100, 0.001)
-        )
-        self.assertEqual(
-            0, genotyper.Genotyper.get_min_cov_to_be_more_likely_than_error(0, 0.001)
-        )
-        with self.assertRaises(RuntimeError):
-            genotyper.Genotyper.get_min_cov_to_be_more_likely_than_error(10000, 0.5)
+def test_init():
+    """test init"""
+    gtyper = genotyper.Genotyper(0, 20, 0.0001)
+    assert gtyper.use_nbinom
+    assert gtyper.min_cov_more_than_error == 0
+    assert gtyper.no_of_successes == 0
+    assert gtyper.prob_of_success == 0
 
-    def test_singleton_alleles_and_coverage(self):
-        """test _singleton_alleles_and_coverage"""
-        allele_combination_cov = {"1": 20, "3": 1}
-        allele_groups_dict = {"1": {0}, "2": {1}, "3": {1, 2}, "4": {5, 6}}
-        self.assertEqual(
-            {0: 20},
-            genotyper.Genotyper._singleton_alleles_and_coverage(
-                allele_combination_cov, allele_groups_dict
-            ),
-        )
-        allele_combination_cov["2"] = 42
-        self.assertEqual(
-            {0: 20, 1: 42},
-            genotyper.Genotyper._singleton_alleles_and_coverage(
-                allele_combination_cov, allele_groups_dict
-            ),
-        )
+    gtyper = genotyper.Genotyper(10, 20, 0.0001)
+    assert gtyper.use_nbinom
+    assert gtyper.no_of_successes == 10
+    assert gtyper.prob_of_success == 0.5
+    assert gtyper.min_cov_more_than_error == 1
 
-    def test_total_coverage(self):
-        """test _total_coverage"""
-        self.assertEqual(0, genotyper.Genotyper._total_coverage({}))
-        self.assertEqual(1, genotyper.Genotyper._total_coverage({"x": 1}))
-        self.assertEqual(42, genotyper.Genotyper._total_coverage({"x": 1, "y": 41}))
+    gtyper = genotyper.Genotyper(10, 20, 0.01)
+    assert gtyper.use_nbinom
+    assert gtyper.no_of_successes == 10
+    assert gtyper.prob_of_success == 0.5
+    assert gtyper.min_cov_more_than_error == 2
+
+    gtyper = genotyper.Genotyper(100, 200, 0.001)
+    assert gtyper.use_nbinom
+    assert gtyper.no_of_successes == 100
+    assert gtyper.prob_of_success == 0.5
+    assert gtyper.min_cov_more_than_error == 8
+
+    gtyper = genotyper.Genotyper(10, 5, 0.01)
+    assert not gtyper.use_nbinom
+    assert gtyper.no_of_successes == None
+    assert gtyper.prob_of_success == None
+    assert gtyper.min_cov_more_than_error == 2
 
 
-    def test_haploid_allele_coverages(self):
-        """test  _haploid_allele_coverages"""
-        allele_combination_cov = {"1": 20, "2": 1}
-        allele_groups_dict = {"0": {0}, "1": {1}, "2": {1, 2}, "3": {5, 6}}
-        num_distinct_alleles = 7 # 1 + the max allele index
-        self.assertEqual(
-            [0, 21, 1, 0, 0, 0, 0],
-            genotyper.Genotyper._haploid_allele_coverages(
-                7, allele_combination_cov, allele_groups_dict
-            ),
-        )
+def test_singleton_alleles_and_coverage():
+    """test _singleton_alleles_and_coverage"""
+    allele_combination_cov = {"1": 20, "3": 1}
+    allele_groups_dict = {"1": {0}, "2": {1}, "3": {1, 2}, "4": {5, 6}}
+    got = genotyper.Genotyper._singleton_alleles_and_coverage(
+        allele_combination_cov, allele_groups_dict
+    )
+    assert got == {0: 20}
 
-    def test_coverage_of_diploid_alleles_equal_dispatching(self):
-        """
-        test _coverage_of_diploid_alleles function
-        # Equiv class -> coverage:
-        #   {0,1}: 9
-        We collect coverages of alleles 0 and 1.
-        This is an edge case where the only coverage is on both: then we dispatch equally.
-        """
-        allele_combination_cov = {"1": 9}
-        allele_groups_dict = {"1": {0, 1}}
-        self.assertEqual(
-            (4.5, 4.5),
-            genotyper.Genotyper._coverage_of_diploid_alleles(
-                0, 1, allele_combination_cov, allele_groups_dict,
-            ),
-        )
+    allele_combination_cov["2"] = 42
+    got = genotyper.Genotyper._singleton_alleles_and_coverage(
+        allele_combination_cov, allele_groups_dict
+    )
+    assert got == {0: 20, 1: 42}
 
-    def test_coverage_of_diploid_alleles_correct_dispatching(self):
-        """
-        test _coverage_of_diploid_alleles function
-        # Equiv class -> coverage:
-        #   {0}: 17
-        #   {1}: 80
-        #   {0,1}: 10
-        #   {0,2): 3
-        We collect coverage for alleles 0 and 1: 20 units specific to 0, 80 specific to 1.
-        Thus we expect a 1:4 dispatching ratio of the 10 reads which agree with both 0 and 1.
-        """
-        allele_combination_cov = {"1": 17, "2": 80, "3": 10, "4": 3}
-        allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {0, 2}}
-        self.assertEqual(
-            (22, 88),
-            genotyper.Genotyper._coverage_of_diploid_alleles(
-                0, 1, allele_combination_cov, allele_groups_dict,
-            ),
-        )
 
-    def test_log_likelihood_homozygous(self):
-        """test _log_likelihood_homozygous"""
-        self.assertEqual(
-            -26.71,
-            round(
-                genotyper.Genotyper._log_likelihood_homozygous(100, 90, 95, 0.01, 5, 5),
-                2,
-            ),
-        )
-        self.assertEqual(
-            -44.54,
-            round(
-                genotyper.Genotyper._log_likelihood_homozygous(10, 1, 9, 0.01, 5, 5), 2
-            ),
-        )
+def test_total_coverage():
+    """test _total_coverage"""
+    f = genotyper.Genotyper._total_coverage
+    assert f({}) == 0
+    assert f({"x": 1}) == 1
+    assert f({"x": 1, "y": 41}) == 42
 
-    def test_log_likelihood_heterozygous(self):
-        """test _log_likelihood_heterozygous"""
-        # _log_likelihood_heterozygous(cls, mean_depth, allele_depth1, allele_depth2, total_depth,
-        #    error_rate, allele_length1, allele_length2, non_zeros1, non_zeros2):
-        self.assertEqual(
-            -52.97,
-            round(
-                genotyper.Genotyper._log_likelihood_heterozygous(
-                    100, 45, 40, 95, 0.01, 3, 3, 3, 3
-                ),
-                2,
-            ),
-        )
-        self.assertEqual(
-            -86.31,
-            round(
-                genotyper.Genotyper._log_likelihood_heterozygous(
-                    100, 45, 40, 95, 0.01, 3, 3, 2, 2
-                ),
-                2,
-            ),
-        )
 
-    def test_calculate_log_likelihoods(self):
-        """test _calculate_log_likelihoods"""
-        mean_depth = 20
-        error_rate = 0.01
-        allele_combination_cov = {"1": 2, "2": 20, "3": 1}
-        allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
-        allele_per_base_cov = [[0, 1], [20, 19]]
-        gtyper = genotyper.Genotyper(
-            mean_depth,
-            error_rate,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-        )
-        depth0 = round(3/23, 4)
-        depth01 = 1
-        depth1 = round(21/23, 4)
-        gtyper._calculate_log_likelihoods()
-        expected = [({1}, -11.68, depth1), ({0, 1}, -22.92, depth01), ({0}, -124.91, depth0)]
-        self.assertEqual(3, len(gtyper.likelihoods))
-        gtyper.likelihoods = [(x[0], round(x[1], 2), x[2]) for x in gtyper.likelihoods]
-        self.assertEqual(expected, gtyper.likelihoods)
+def test_haploid_allele_coverages():
+    """test  _haploid_allele_coverages"""
+    allele_combination_cov = {"1": 20, "2": 1}
+    allele_groups_dict = {"0": {0}, "1": {1}, "2": {1, 2}, "3": {5, 6}}
+    num_distinct_alleles = 7  # 1 + the max allele index
+    got = genotyper.Genotyper._haploid_allele_coverages(
+        num_distinct_alleles, allele_combination_cov, allele_groups_dict
+    )
+    assert got == [0, 21, 1, 0, 0, 0, 0]
 
-    def test_run_with_call_hets_false(self):
-        """test run"""
-        mean_depth = 20
-        error_rate = 0.01
-        allele_combination_cov = {"1": 2, "2": 20, "3": 1}
-        allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
-        allele_per_base_cov = [[0, 1], [20, 19]]
-        gtyper = genotyper.Genotyper(
-            mean_depth,
-            error_rate,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-            call_hets=False,
-        )
-        depth0 = round(3/23, 4)
-        depth01 = 1
-        depth1 = round(21/23, 4)
-        expected = [({1}, -11.68, depth1), ({0}, -124.91, depth0)]
-        gtyper.run()
-        self.assertEqual(len(expected), len(gtyper.likelihoods))
-        for i in range(len(expected)):
-            self.assertEqual(expected[i][0], gtyper.likelihoods[i][0])
-            self.assertAlmostEqual(expected[i][1], gtyper.likelihoods[i][1], places=2)
-            self.assertEqual(expected[i][2], gtyper.likelihoods[i][2])
 
-    def test_run(self):
-        """test run"""
-        mean_depth = 20
-        error_rate = 0.01
-        allele_combination_cov = {"1": 2, "2": 20, "3": 1}
-        allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
-        allele_per_base_cov = [[0, 1], [20, 19]]
-        gtyper = genotyper.Genotyper(
-            mean_depth,
-            error_rate,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-        )
-        depth0 = round(3/23, 4)
-        depth01 = 1
-        depth1 = round(21/23, 4)
-        expected = [({1}, -11.68, depth1), ({0, 1}, -22.92, depth01), ({0}, -124.91, depth0)]
-        gtyper.run()
-        self.assertEqual(len(expected), len(gtyper.likelihoods))
-        for i in range(len(expected)):
-            self.assertEqual(expected[i][0], gtyper.likelihoods[i][0])
-            self.assertAlmostEqual(expected[i][1], gtyper.likelihoods[i][1], places=2)
-            self.assertEqual(expected[i][2], gtyper.likelihoods[i][2])
+def test_coverage_of_diploid_alleles_equal_dispatching():
+    """
+    test _coverage_of_diploid_alleles function
+    # Equiv class -> coverage:
+    #   {0,1}: 9
+    We collect coverages of alleles 0 and 1.
+    This is an edge case where the only coverage is on both: then we dispatch equally.
+    """
+    allele_combination_cov = {"1": 9}
+    allele_groups_dict = {"1": {0, 1}}
+    got = genotyper.Genotyper._coverage_of_diploid_alleles(
+        0, 1, allele_combination_cov, allele_groups_dict,
+    )
+    assert got == (4.5, 4.5)
 
-    def test_run_zero_coverage(self):
-        """test run when all alleles have zero coverage"""
-        mean_depth = 20
-        error_rate = 0.01
-        allele_combination_cov = {}
-        allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
-        allele_per_base_cov = [[0], [0, 0]]
-        gtyper = genotyper.Genotyper(
-            mean_depth,
-            error_rate,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-        )
-        gtyper.run()
-        self.assertEqual({"."}, gtyper.genotype)
-        self.assertEqual(0.0, gtyper.genotype_confidence)
-        self.assertEqual(".", gtyper.genotype_frs)
 
-    def test_nomatherror_mean_depth0(self):
-        """
-        Can get a mean_depth of zero but try to genotype a non-zero coverage site due to rounding imprecision.
-        In which case we need to avoid trying to do log(0) in likelihood calculation and should return no call.
-        """
-        mean_depth = 0
-        error_rate = 0.01
-        allele_combination_cov = {"1": 1}
-        allele_groups_dict = {"1": {0}, "2": {1}}
-        allele_per_base_cov = [[1], [0, 0]]
-        gtyper = genotyper.Genotyper(
-            mean_depth,
-            error_rate,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-        )
-        gtyper.run()
-        self.assertEqual({"."}, gtyper.genotype)
-        self.assertEqual(0.0, gtyper.genotype_confidence)
-        self.assertEqual(".", gtyper.genotype_frs)
+def test_coverage_of_diploid_alleles_correct_dispatching():
+    """
+    test _coverage_of_diploid_alleles function
+    # Equiv class -> coverage:
+    #   {0}: 17
+    #   {1}: 80
+    #   {0,1}: 10
+    #   {0,2): 3
+    We collect coverage for alleles 0 and 1: 20 units specific to 0, 80 specific to 1.
+    Thus we expect a 1:4 dispatching ratio of the 10 reads which agree with both 0 and 1.
+    """
+    allele_combination_cov = {"1": 17, "2": 80, "3": 10, "4": 3}
+    allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {0, 2}}
+    got = genotyper.Genotyper._coverage_of_diploid_alleles(
+        0, 1, allele_combination_cov, allele_groups_dict,
+    )
+    assert got == (22, 88)
+
+
+def test_log_likelihood_homozygous():
+    """test _log_likelihood_homozygous"""
+    gtyper = genotyper.Genotyper(100, 200, 0.01)
+    allele_depth = 90
+    total_depth = 95
+    allele_length = 5
+    non_zeros = allele_length
+    got = gtyper._log_likelihood_homozygous(
+        allele_depth, total_depth, allele_length, non_zeros
+    )
+    assert round(got, 2) == -26.71
+
+    gtyper = genotyper.Genotyper(10, 200, 0.01)
+    allele_depth = 1
+    total_depth = 9
+    got = gtyper._log_likelihood_homozygous(
+        allele_depth, total_depth, allele_length, non_zeros
+    )
+    assert round(got, 2) == -44.77
+
+    gtyper = genotyper.Genotyper(10, 200, 0.01, force_poisson=True)
+    allele_depth = 1
+    total_depth = 9
+    got = gtyper._log_likelihood_homozygous(
+        allele_depth, total_depth, allele_length, non_zeros
+    )
+    assert round(got, 2) == -44.54
+
+
+def test_log_likelihood_heterozygous():
+    """test _log_likelihood_heterozygous"""
+    gtyper = genotyper.Genotyper(100, 200, 0.01)
+    allele_depth1 = 45
+    allele_depth2 = 40
+    total_depth = 95
+    allele_length1 = 3
+    allele_length2 = 3
+    non_zeros1 = 3
+    non_zeros2 = 3
+    got = gtyper._log_likelihood_heterozygous(
+        allele_depth1,
+        allele_depth2,
+        total_depth,
+        allele_length1,
+        allele_length2,
+        non_zeros1,
+        non_zeros2,
+    )
+    assert round(got, 2) == -52.97
+
+    non_zeros1 = 2
+    non_zeros2 = 2
+    got = gtyper._log_likelihood_heterozygous(
+        allele_depth1,
+        allele_depth2,
+        total_depth,
+        allele_length1,
+        allele_length2,
+        non_zeros1,
+        non_zeros2,
+    )
+    assert round(got, 2) == -86.31
+
+
+def test_calculate_log_likelihoods():
+    """test _calculate_log_likelihoods"""
+    gtyper = genotyper.Genotyper(20, 40, 0.01, call_hets=True)
+    allele_combination_cov = {"1": 2, "2": 20, "3": 1}
+    allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
+    allele_per_base_cov = [[0, 1], [20, 19]]
+    depth0 = round(3 / 23, 4)
+    depth01 = 1
+    depth1 = round(21 / 23, 4)
+    gtyper._init_alleles_and_genotypes(
+        allele_combination_cov=allele_combination_cov,
+        allele_per_base_cov=allele_per_base_cov,
+        allele_groups_dict=allele_groups_dict,
+    )
+    gtyper._calculate_log_likelihoods()
+    assert len(gtyper.likelihoods) == 3
+    expected = [
+        ({1}, -11.68, depth1),
+        ({0, 1}, -22.93, depth01),
+        ({0}, -124.91, depth0),
+    ]
+    gtyper.likelihoods = [(x[0], round(x[1], 2), x[2]) for x in gtyper.likelihoods]
+    assert gtyper.likelihoods == expected
+
+
+def test_run_with_call_hets_false():
+    """test run call_hets False"""
+    gtyper = genotyper.Genotyper(20, 40, 0.01, call_hets=False)
+    allele_combination_cov = {"1": 2, "2": 20, "3": 1}
+    allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
+    allele_per_base_cov = [[0, 1], [20, 19]]
+    gtyper.run(allele_combination_cov, allele_per_base_cov, allele_groups_dict)
+    depth0 = round(3 / 23, 4)
+    depth1 = round(21 / 23, 4)
+    expected = [({1}, -11.68, depth1), ({0}, -124.91, depth0)]
+    assert len(gtyper.likelihoods) == len(expected)
+    for i in range(len(expected)):
+        assert gtyper.likelihoods[i][0] == expected[i][0]
+        assert round(gtyper.likelihoods[i][1], 2) == round(expected[i][1], 2)
+        assert gtyper.likelihoods[i][2] == expected[i][2]
+
+
+def test_run():
+    """test run call_hets True"""
+    gtyper = genotyper.Genotyper(20, 40, 0.01, call_hets=True)
+    allele_combination_cov = {"1": 2, "2": 20, "3": 1}
+    allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
+    allele_per_base_cov = [[0, 1], [20, 19]]
+    gtyper.run(allele_combination_cov, allele_per_base_cov, allele_groups_dict)
+    depth0 = round(3 / 23, 4)
+    depth01 = 1
+    depth1 = round(21 / 23, 4)
+    expected = [
+        ({1}, -11.68, depth1),
+        ({0, 1}, -22.93, depth01),
+        ({0}, -124.91, depth0),
+    ]
+    assert len(gtyper.likelihoods) == len(expected)
+    for i in range(len(expected)):
+        assert gtyper.likelihoods[i][0] == expected[i][0]
+        assert round(gtyper.likelihoods[i][1], 2) == round(expected[i][1], 2)
+        assert gtyper.likelihoods[i][2] == expected[i][2]
+
+
+def test_run_zero_coverage():
+    """test run when all alleles have zero coverage"""
+    gtyper = genotyper.Genotyper(20, 40, 0.01, call_hets=True)
+    allele_combination_cov = {}
+    allele_groups_dict = {"1": {0}, "2": {1}, "3": {0, 1}, "4": {2}}
+    allele_per_base_cov = [[0], [0, 0]]
+    gtyper.run(allele_combination_cov, allele_per_base_cov, allele_groups_dict)
+    assert gtyper.genotype == {"."}
+    assert gtyper.genotype_confidence == 0.0
+    assert gtyper.genotype_frs == "."
+
+
+def test_nomatherror_mean_depth0():
+    """
+    Can get a mean_depth of zero but try to genotype a non-zero coverage site due to rounding imprecision.
+    In which case we need to avoid trying to do log(0) in likelihood calculation and should return no call.
+    """
+    gtyper = genotyper.Genotyper(0, 0, 0.01, call_hets=True)
+    allele_combination_cov = {"1": 1}
+    allele_groups_dict = {"1": {0}, "2": {1}}
+    allele_per_base_cov = [[1], [0, 0]]
+    gtyper.run(allele_combination_cov, allele_per_base_cov, allele_groups_dict)
+    assert gtyper.genotype == {"."}
+    assert gtyper.genotype_confidence == 0.0
+    assert gtyper.genotype_frs == "."

--- a/tests/gramtools_test.py
+++ b/tests/gramtools_test.py
@@ -25,6 +25,7 @@ def test_build_json_file_is_good():
     )
     assert not gramtools._build_json_file_is_good(build_file)
 
+
 def test_run_gramtools_build():
     """test run_gramtools_build"""
     tmp_out_build = "tmp.run_gramtools.out.build"
@@ -32,11 +33,10 @@ def test_run_gramtools_build():
         shutil.rmtree(tmp_out_build)
     vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
     ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
-    gramtools.run_gramtools_build(
-        tmp_out_build, vcf_file, ref_file, 150, kmer_size=5
-    )
+    gramtools.run_gramtools_build(tmp_out_build, vcf_file, ref_file, 150, kmer_size=5)
     assert os.path.exists(tmp_out_build)
     shutil.rmtree(tmp_out_build)
+
 
 def test_run_gramtools():
     """test run_gramtools"""
@@ -62,12 +62,19 @@ def test_run_gramtools():
     # that gramtools can run. Parsing its output is checked elsewhere.
     assert os.path.exists(tmp_out_build)
     assert os.path.exists(tmp_out_quasimap)
-    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json"))
-    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "grouped_allele_counts_coverage.json"))
+    assert os.path.exists(
+        os.path.join(tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json")
+    )
+    assert os.path.exists(
+        os.path.join(
+            tmp_out_quasimap, "quasimap_outputs", "grouped_allele_counts_coverage.json"
+        )
+    )
     assert "gramtools_build" in build_report
     assert "gramtools_cpp_quasimap" in quasimap_report
     shutil.rmtree(tmp_out_build)
     shutil.rmtree(tmp_out_quasimap)
+
 
 def test_run_gramtools_fails():
     """test run_gramtools when fails"""
@@ -97,6 +104,7 @@ def test_run_gramtools_fails():
         )
     shutil.rmtree(tmp_out_build)
 
+
 def test_run_gramtools_two_reads_files():
     """test run_gramtools"""
     tmp_out_build = "tmp.run_gramtools.2files.out.build"
@@ -122,10 +130,17 @@ def test_run_gramtools_two_reads_files():
     # that gramtools can run. Parsing its output is checked elsewhere.
     assert os.path.exists(tmp_out_build)
     assert os.path.exists(tmp_out_quasimap)
-    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json"))
-    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "grouped_allele_counts_coverage.json"))
+    assert os.path.exists(
+        os.path.join(tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json")
+    )
+    assert os.path.exists(
+        os.path.join(
+            tmp_out_quasimap, "quasimap_outputs", "grouped_allele_counts_coverage.json"
+        )
+    )
     shutil.rmtree(tmp_out_build)
     shutil.rmtree(tmp_out_quasimap)
+
 
 def test_load_gramtools_vcf_and_allele_coverage_files():
     """test load_gramtools_vcf_and_allele_coverage_files"""
@@ -133,9 +148,14 @@ def test_load_gramtools_vcf_and_allele_coverage_files():
     quasimap_dir = os.path.join(
         data_dir, "load_gramtools_vcf_and_allele_coverage_files.quasimap"
     )
-    got_mean_depth, got_depth_variance, got_vcf_header, got_vcf_records, got_allele_coverage, got_allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
-        vcf_file, quasimap_dir
-    )
+    (
+        got_mean_depth,
+        got_depth_variance,
+        got_vcf_header,
+        got_vcf_records,
+        got_allele_coverage,
+        got_allele_groups,
+    ) = gramtools.load_gramtools_vcf_and_allele_coverage_files(vcf_file, quasimap_dir)
 
     expected_header, expected_vcf_records = vcf_file_read.vcf_file_to_list(vcf_file)
     assert got_vcf_header == expected_header
@@ -148,25 +168,18 @@ def test_load_gramtools_vcf_and_allele_coverage_files():
         data_dir, "load_gramtools_vcf_and_allele_coverage.short.vcf"
     )
     with pytest.raises(Exception):
-        gramtools.load_gramtools_vcf_and_allele_coverage_files(
-            vcf_file, quasimap_dir
-        )
+        gramtools.load_gramtools_vcf_and_allele_coverage_files(vcf_file, quasimap_dir)
 
-    vcf_file = os.path.join(
-        data_dir, "load_gramtools_vcf_and_allele_coverage.long.vcf"
-    )
+    vcf_file = os.path.join(data_dir, "load_gramtools_vcf_and_allele_coverage.long.vcf")
     with pytest.raises(Exception):
-        gramtools.load_gramtools_vcf_and_allele_coverage_files(
-            vcf_file, quasimap_dir
-        )
+        gramtools.load_gramtools_vcf_and_allele_coverage_files(vcf_file, quasimap_dir)
 
     vcf_file = os.path.join(
         data_dir, "load_gramtools_vcf_and_allele_coverage.bad_allele_count.vcf"
     )
     with pytest.raises(Exception):
-        gramtools.load_gramtools_vcf_and_allele_coverage_files(
-            vcf_file, quasimap_dir
-        )
+        gramtools.load_gramtools_vcf_and_allele_coverage_files(vcf_file, quasimap_dir)
+
 
 def test_update_vcf_record_using_gramtools_allele_depths_heterozygous():
     """test update_using_gramtools_allele_depths heterozygous"""
@@ -186,17 +199,14 @@ def test_update_vcf_record_using_gramtools_allele_depths_heterozygous():
         mean_depth, depth_variance, error_rate, call_hets=True,
     )
     got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
-        record,
-        gtyper,
-        allele_combination_cov,
-        allele_per_base_cov,
-        allele_groups_dict,
+        record, gtyper, allele_combination_cov, allele_per_base_cov, allele_groups_dict,
     )
     assert record == expected
     expected_filtered = vcf_record.VcfRecord(
         "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t0/1:17:1.1333:9,7:1.0:54.43"
     )
     assert got_filtered == expected_filtered
+
 
 def test_update_vcf_record_using_gramtools_allele_depths_homozygous():
     """test update_using_gramtools_allele_depths homozygous"""
@@ -216,17 +226,14 @@ def test_update_vcf_record_using_gramtools_allele_depths_homozygous():
         mean_depth, depth_variance, error_rate, call_hets=False,
     )
     got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
-        record,
-        gtyper,
-        allele_combination_cov,
-        allele_per_base_cov,
-        allele_groups_dict,
+        record, gtyper, allele_combination_cov, allele_per_base_cov, allele_groups_dict,
     )
     assert record == expected
     expected_filtered = vcf_record.VcfRecord(
         "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t1/1:81:0.9529:1,80:0.9877:708.01"
     )
     assert got_filtered == expected_filtered
+
 
 def test_update_vcf_record_using_gramtools_allele_depths_not_callable():
     """test update_using_gramtools_allele_depths not callable"""
@@ -246,14 +253,11 @@ def test_update_vcf_record_using_gramtools_allele_depths_not_callable():
         mean_depth, depth_variance, error_rate, call_hets=False,
     )
     got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
-        record,
-        gtyper,
-        allele_combination_cov,
-        allele_per_base_cov,
-        allele_groups_dict,
+        record, gtyper, allele_combination_cov, allele_per_base_cov, allele_groups_dict,
     )
     assert record == expected
     assert got_filtered == expected
+
 
 def test_write_vcf_annotated_using_coverage_from_gramtools():
     """test write_vcf_annotated_using_coverage_from_gramtools"""
@@ -263,12 +267,17 @@ def test_write_vcf_annotated_using_coverage_from_gramtools():
     quasimap_dir = os.path.join(
         data_dir, "write_vcf_annotated_using_coverage_from_gramtools.quasimap"
     )
-    mean_depth, depth_variance, vcf_header, vcf_records, allele_coverage, allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
+    (
+        mean_depth,
+        depth_variance,
+        vcf_header,
+        vcf_records,
+        allele_coverage,
+        allele_groups,
+    ) = gramtools.load_gramtools_vcf_and_allele_coverage_files(
         vcf_file_in, quasimap_dir
     )
-    tmp_outfile = (
-        "tmp.gramtools.write_vcf_annotated_using_coverage_from_gramtools.vcf"
-    )
+    tmp_outfile = "tmp.gramtools.write_vcf_annotated_using_coverage_from_gramtools.vcf"
     tmp_outfile_filtered = tmp_outfile + ".filter.vcf"
     error_rate = 0.001
     gramtools.write_vcf_annotated_using_coverage_from_gramtools(
@@ -313,6 +322,7 @@ def test_write_vcf_annotated_using_coverage_from_gramtools():
     check_vcfs(expected_vcf_filtered, tmp_outfile_filtered)
     os.unlink(tmp_outfile)
     os.unlink(tmp_outfile_filtered)
+
 
 def test_load_allele_files():
     """test load_allele_files"""

--- a/tests/gramtools_test.py
+++ b/tests/gramtools_test.py
@@ -1,56 +1,92 @@
 import datetime
 import shutil
 import os
-import unittest
+import pytest
 
 from cluster_vcf_records import vcf_file_read, vcf_record
 
-from minos import gramtools
+from minos import genotyper, gramtools
 from minos import __version__ as minos_version
 
 this_dir = os.path.dirname(os.path.abspath(__file__))
 data_dir = os.path.join(this_dir, "data", "gramtools")
 
 
-class TestGramtools(unittest.TestCase):
-    def test_build_json_file_is_good(self):
-        """test _build_json_file_is_good"""
-        build_file = os.path.join(data_dir, "build_json_file_is_good.good.json")
-        self.assertTrue(gramtools._build_json_file_is_good(build_file))
-        build_file = os.path.join(data_dir, "build_json_file_is_good.bad.1.json")
-        self.assertFalse(gramtools._build_json_file_is_good(build_file))
-        build_file = os.path.join(data_dir, "build_json_file_is_good.bad.2.json")
-        self.assertFalse(gramtools._build_json_file_is_good(build_file))
-        build_file = os.path.join(
-            data_dir, "build_json_file_is_good.bad.2.json_thisfiledoesnotexist"
-        )
-        self.assertFalse(gramtools._build_json_file_is_good(build_file))
+def test_build_json_file_is_good():
+    """test _build_json_file_is_good"""
+    build_file = os.path.join(data_dir, "build_json_file_is_good.good.json")
+    assert gramtools._build_json_file_is_good(build_file)
+    build_file = os.path.join(data_dir, "build_json_file_is_good.bad.1.json")
+    assert not gramtools._build_json_file_is_good(build_file)
+    build_file = os.path.join(data_dir, "build_json_file_is_good.bad.2.json")
+    assert not gramtools._build_json_file_is_good(build_file)
+    build_file = os.path.join(
+        data_dir, "build_json_file_is_good.bad.2.json_thisfiledoesnotexist"
+    )
+    assert not gramtools._build_json_file_is_good(build_file)
 
-    def test_run_gramtools_build(self):
-        """test run_gramtools_build"""
-        tmp_out_build = "tmp.run_gramtools.out.build"
-        if os.path.exists(tmp_out_build):
-            shutil.rmtree(tmp_out_build)
-        vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
-        ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
-        gramtools.run_gramtools_build(
-            tmp_out_build, vcf_file, ref_file, 150, kmer_size=5
-        )
-        self.assertTrue(os.path.exists(tmp_out_build))
+def test_run_gramtools_build():
+    """test run_gramtools_build"""
+    tmp_out_build = "tmp.run_gramtools.out.build"
+    if os.path.exists(tmp_out_build):
         shutil.rmtree(tmp_out_build)
+    vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
+    ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
+    gramtools.run_gramtools_build(
+        tmp_out_build, vcf_file, ref_file, 150, kmer_size=5
+    )
+    assert os.path.exists(tmp_out_build)
+    shutil.rmtree(tmp_out_build)
 
-    def test_run_gramtools(self):
-        """test run_gramtools"""
-        tmp_out_build = "tmp.run_gramtools.out.build"
-        tmp_out_quasimap = "tmp.run_gramtools.out.quasimap"
-        if os.path.exists(tmp_out_build):
-            shutil.rmtree(tmp_out_build)
-        if os.path.exists(tmp_out_quasimap):
-            shutil.rmtree(tmp_out_quasimap)
-        vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
-        ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
-        reads_file = os.path.join(data_dir, "run_gramtools.reads.fq")
-        build_report, quasimap_report = gramtools.run_gramtools(
+def test_run_gramtools():
+    """test run_gramtools"""
+    tmp_out_build = "tmp.run_gramtools.out.build"
+    tmp_out_quasimap = "tmp.run_gramtools.out.quasimap"
+    if os.path.exists(tmp_out_build):
+        shutil.rmtree(tmp_out_build)
+    if os.path.exists(tmp_out_quasimap):
+        shutil.rmtree(tmp_out_quasimap)
+    vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
+    ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
+    reads_file = os.path.join(data_dir, "run_gramtools.reads.fq")
+    build_report, quasimap_report = gramtools.run_gramtools(
+        tmp_out_build,
+        tmp_out_quasimap,
+        vcf_file,
+        ref_file,
+        reads_file,
+        150,
+        kmer_size=5,
+    )
+    # We're trusing gramtools output for this test. The point here is to check
+    # that gramtools can run. Parsing its output is checked elsewhere.
+    assert os.path.exists(tmp_out_build)
+    assert os.path.exists(tmp_out_quasimap)
+    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json"))
+    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "grouped_allele_counts_coverage.json"))
+    assert "gramtools_build" in build_report
+    assert "gramtools_cpp_quasimap" in quasimap_report
+    shutil.rmtree(tmp_out_build)
+    shutil.rmtree(tmp_out_quasimap)
+
+def test_run_gramtools_fails():
+    """test run_gramtools when fails"""
+    # Don't trust error code. Instead, we check
+    # that gramtools wrote the quesimap files we expected, as this
+    # is a good proxy for success. One way to stop these files
+    # from being written is to have no variants in the input VCF,
+    # so that's what we do here
+    tmp_out_build = "tmp.run_gramtools.fail.out.build"
+    tmp_out_quasimap = "tmp.run_gramtools.fail.out.quasimap"
+    if os.path.exists(tmp_out_build):
+        shutil.rmtree(tmp_out_build)
+    if os.path.exists(tmp_out_quasimap):
+        shutil.rmtree(tmp_out_quasimap)
+    vcf_file = os.path.join(data_dir, "run_gramtools.empty.vcf")
+    ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
+    reads_file = os.path.join(data_dir, "run_gramtools.reads.fq")
+    with pytest.raises(Exception):
+        gramtools.run_gramtools(
             tmp_out_build,
             tmp_out_quasimap,
             vcf_file,
@@ -59,296 +95,242 @@ class TestGramtools(unittest.TestCase):
             150,
             kmer_size=5,
         )
-        # We're trusing gramtools output for this test. The point here is to check
-        # that gramtools can run. Parsing its output is checked elsewhere.
-        self.assertTrue(os.path.exists(tmp_out_build))
-        self.assertTrue(os.path.exists(tmp_out_quasimap))
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json"
-                )
-            )
-        )
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    tmp_out_quasimap,
-                    "quasimap_outputs",
-                    "grouped_allele_counts_coverage.json",
-                )
-            )
-        )
-        self.assertIn("gramtools_build", build_report)
-        self.assertIn("gramtools_cpp_quasimap", quasimap_report)
+    shutil.rmtree(tmp_out_build)
+
+def test_run_gramtools_two_reads_files():
+    """test run_gramtools"""
+    tmp_out_build = "tmp.run_gramtools.2files.out.build"
+    tmp_out_quasimap = "tmp.run_gramtools.2files.out.quasimap"
+    if os.path.exists(tmp_out_build):
         shutil.rmtree(tmp_out_build)
+    if os.path.exists(tmp_out_quasimap):
         shutil.rmtree(tmp_out_quasimap)
+    vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
+    ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
+    reads_file1 = os.path.join(data_dir, "run_gramtools.reads_1.fq")
+    reads_file2 = os.path.join(data_dir, "run_gramtools.reads_2.fq")
+    gramtools.run_gramtools(
+        tmp_out_build,
+        tmp_out_quasimap,
+        vcf_file,
+        ref_file,
+        [reads_file1, reads_file2],
+        150,
+        kmer_size=5,
+    )
+    # We're trusing gramtools output for this test. The point here is to check
+    # that gramtools can run. Parsing its output is checked elsewhere.
+    assert os.path.exists(tmp_out_build)
+    assert os.path.exists(tmp_out_quasimap)
+    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json"))
+    assert os.path.exists(os.path.join(tmp_out_quasimap, "quasimap_outputs", "grouped_allele_counts_coverage.json"))
+    shutil.rmtree(tmp_out_build)
+    shutil.rmtree(tmp_out_quasimap)
 
-    def test_run_gramtools_fails(self):
-        """test run_gramtools when fails"""
-        # Don't trust error code. Instead, we check
-        # that gramtools wrote the quesimap files we expected, as this
-        # is a good proxy for success. One way to stop these files
-        # from being written is to have no variants in the input VCF,
-        # so that's what we do here
-        tmp_out_build = "tmp.run_gramtools.fail.out.build"
-        tmp_out_quasimap = "tmp.run_gramtools.fail.out.quasimap"
-        if os.path.exists(tmp_out_build):
-            shutil.rmtree(tmp_out_build)
-        if os.path.exists(tmp_out_quasimap):
-            shutil.rmtree(tmp_out_quasimap)
-        vcf_file = os.path.join(data_dir, "run_gramtools.empty.vcf")
-        ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
-        reads_file = os.path.join(data_dir, "run_gramtools.reads.fq")
-        with self.assertRaises(Exception):
-            gramtools.run_gramtools(
-                tmp_out_build,
-                tmp_out_quasimap,
-                vcf_file,
-                ref_file,
-                reads_file,
-                150,
-                kmer_size=5,
-            )
-        shutil.rmtree(tmp_out_build)
+def test_load_gramtools_vcf_and_allele_coverage_files():
+    """test load_gramtools_vcf_and_allele_coverage_files"""
+    vcf_file = os.path.join(data_dir, "load_gramtools_vcf_and_allele_coverage.vcf")
+    quasimap_dir = os.path.join(
+        data_dir, "load_gramtools_vcf_and_allele_coverage_files.quasimap"
+    )
+    got_mean_depth, got_depth_variance, got_vcf_header, got_vcf_records, got_allele_coverage, got_allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
+        vcf_file, quasimap_dir
+    )
 
-    def test_run_gramtools_two_reads_files(self):
-        """test run_gramtools"""
-        tmp_out_build = "tmp.run_gramtools.2files.out.build"
-        tmp_out_quasimap = "tmp.run_gramtools.2files.out.quasimap"
-        if os.path.exists(tmp_out_build):
-            shutil.rmtree(tmp_out_build)
-        if os.path.exists(tmp_out_quasimap):
-            shutil.rmtree(tmp_out_quasimap)
-        vcf_file = os.path.join(data_dir, "run_gramtools.calls.vcf")
-        ref_file = os.path.join(data_dir, "run_gramtools.ref.fa")
-        reads_file1 = os.path.join(data_dir, "run_gramtools.reads_1.fq")
-        reads_file2 = os.path.join(data_dir, "run_gramtools.reads_2.fq")
-        gramtools.run_gramtools(
-            tmp_out_build,
-            tmp_out_quasimap,
-            vcf_file,
-            ref_file,
-            [reads_file1, reads_file2],
-            150,
-            kmer_size=5,
-        )
-        # We're trusing gramtools output for this test. The point here is to check
-        # that gramtools can run. Parsing its output is checked elsewhere.
-        self.assertTrue(os.path.exists(tmp_out_build))
-        self.assertTrue(os.path.exists(tmp_out_quasimap))
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    tmp_out_quasimap, "quasimap_outputs", "allele_base_coverage.json"
-                )
-            )
-        )
-        self.assertTrue(
-            os.path.exists(
-                os.path.join(
-                    tmp_out_quasimap,
-                    "quasimap_outputs",
-                    "grouped_allele_counts_coverage.json",
-                )
-            )
-        )
-        shutil.rmtree(tmp_out_build)
-        shutil.rmtree(tmp_out_quasimap)
+    expected_header, expected_vcf_records = vcf_file_read.vcf_file_to_list(vcf_file)
+    assert got_vcf_header == expected_header
+    assert got_vcf_records == expected_vcf_records
+    assert got_mean_depth == 10.500
+    assert got_depth_variance == 0.5
 
-    def test_load_gramtools_vcf_and_allele_coverage_files(self):
-        """test load_gramtools_vcf_and_allele_coverage_files"""
-        vcf_file = os.path.join(data_dir, "load_gramtools_vcf_and_allele_coverage.vcf")
-        quasimap_dir = os.path.join(
-            data_dir, "load_gramtools_vcf_and_allele_coverage_files.quasimap"
-        )
-        got_mean_depth, got_depth_variance, got_vcf_header, got_vcf_records, got_allele_coverage, got_allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
+    # now test bad files cause error to be raised
+    vcf_file = os.path.join(
+        data_dir, "load_gramtools_vcf_and_allele_coverage.short.vcf"
+    )
+    with pytest.raises(Exception):
+        gramtools.load_gramtools_vcf_and_allele_coverage_files(
             vcf_file, quasimap_dir
         )
 
-        expected_header, expected_vcf_records = vcf_file_read.vcf_file_to_list(vcf_file)
-        self.assertEqual(expected_header, got_vcf_header)
-        self.assertEqual(expected_vcf_records, got_vcf_records)
-        self.assertEqual(10.500, got_mean_depth)
-        self.assertEqual(0.5, got_depth_variance)
+    vcf_file = os.path.join(
+        data_dir, "load_gramtools_vcf_and_allele_coverage.long.vcf"
+    )
+    with pytest.raises(Exception):
+        gramtools.load_gramtools_vcf_and_allele_coverage_files(
+            vcf_file, quasimap_dir
+        )
 
-        # now test bad files cause error to be raised
-        vcf_file = os.path.join(
-            data_dir, "load_gramtools_vcf_and_allele_coverage.short.vcf"
+    vcf_file = os.path.join(
+        data_dir, "load_gramtools_vcf_and_allele_coverage.bad_allele_count.vcf"
+    )
+    with pytest.raises(Exception):
+        gramtools.load_gramtools_vcf_and_allele_coverage_files(
+            vcf_file, quasimap_dir
         )
-        with self.assertRaises(Exception):
-            gramtools.load_gramtools_vcf_and_allele_coverage_files(
-                vcf_file, quasimap_dir
-            )
 
-        vcf_file = os.path.join(
-            data_dir, "load_gramtools_vcf_and_allele_coverage.long.vcf"
-        )
-        with self.assertRaises(Exception):
-            gramtools.load_gramtools_vcf_and_allele_coverage_files(
-                vcf_file, quasimap_dir
-            )
+def test_update_vcf_record_using_gramtools_allele_depths_heterozygous():
+    """test update_using_gramtools_allele_depths heterozygous"""
+    record = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tA,G,TC\t228\t.\tINDEL;IDV=54;IMF=0.885246;DP=61;VDB=7.33028e-19;SGB=-0.693147;MQSB=0.9725;MQ0F=0;AC=2;AN=2;DP4=0,0,23,31;MQ=57\tGT:PL\t1/1:255,163,0"
+    )
+    allele_combination_cov = {"1": 9, "2": 7, "3": 1}
+    allele_groups_dict = {"1": {0}, "2": {2}, "3": {2, 3}}
+    allele_per_base_cov = [[0], [9], [7], [1, 0]]
+    expected = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tA,G,TC\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t0/2:17:1.1333:9,0,7,0:1.0:54.43"
+    )
+    mean_depth = 15
+    depth_variance = 30
+    error_rate = 0.001
+    gtyper = genotyper.Genotyper(
+        mean_depth, depth_variance, error_rate, call_hets=True,
+    )
+    got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
+        record,
+        gtyper,
+        allele_combination_cov,
+        allele_per_base_cov,
+        allele_groups_dict,
+    )
+    assert record == expected
+    expected_filtered = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t0/1:17:1.1333:9,7:1.0:54.43"
+    )
+    assert got_filtered == expected_filtered
 
-        vcf_file = os.path.join(
-            data_dir, "load_gramtools_vcf_and_allele_coverage.bad_allele_count.vcf"
-        )
-        with self.assertRaises(Exception):
-            gramtools.load_gramtools_vcf_and_allele_coverage_files(
-                vcf_file, quasimap_dir
-            )
+def test_update_vcf_record_using_gramtools_allele_depths_homozygous():
+    """test update_using_gramtools_allele_depths homozygous"""
+    record = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tTC,G\t228\t.\tINDEL;IDV=54;IMF=0.885246;DP=61;VDB=7.33028e-19;SGB=-0.693147;MQSB=0.9725;MQ0F=0;AC=2;AN=2;DP4=0,0,23,31;MQ=57\tGT:PL\t1/1:255,163,0"
+    )
+    allele_combination_cov = {"1": 1, "2": 80}
+    allele_groups_dict = {"1": {0}, "2": {2}, "3": {1, 2}}
+    allele_per_base_cov = [[1], [0, 0], [80]]
+    expected = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tTC,G\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t2/2:81:0.9529:1,0,80:0.9877:708.01"
+    )
+    mean_depth = 85
+    depth_variance = 200
+    error_rate = 0.001
+    gtyper = genotyper.Genotyper(
+        mean_depth, depth_variance, error_rate, call_hets=False,
+    )
+    got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
+        record,
+        gtyper,
+        allele_combination_cov,
+        allele_per_base_cov,
+        allele_groups_dict,
+    )
+    assert record == expected
+    expected_filtered = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t1/1:81:0.9529:1,80:0.9877:708.01"
+    )
+    assert got_filtered == expected_filtered
 
-    def test_update_vcf_record_using_gramtools_allele_depths_heterozygous(self):
-        """test update_using_gramtools_allele_depths heterozygous"""
-        record = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tA,G,TC\t228\t.\tINDEL;IDV=54;IMF=0.885246;DP=61;VDB=7.33028e-19;SGB=-0.693147;MQSB=0.9725;MQ0F=0;AC=2;AN=2;DP4=0,0,23,31;MQ=57\tGT:PL\t1/1:255,163,0"
-        )
-        allele_combination_cov = {"1": 9, "2": 7, "3": 1}
-        allele_groups_dict = {"1": {0}, "2": {2}, "3": {2, 3}}
-        allele_per_base_cov = [[0], [9], [7], [1, 0]]
-        expected = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tA,G,TC\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t0/2:17:1.1333:9,0,7,0:1.0:54.46"
-        )
-        mean_depth = 15
-        error_rate = 0.001
-        got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
-            record,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-            mean_depth,
-            error_rate,
-        )
-        self.assertEqual(expected, record)
-        expected_filtered = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t0/1:17:1.1333:9,7:1.0:54.46"
-        )
-        self.assertEqual(expected_filtered, got_filtered)
+def test_update_vcf_record_using_gramtools_allele_depths_not_callable():
+    """test update_using_gramtools_allele_depths not callable"""
+    record = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tG,TC\t228\t.\tINDEL;IDV=54;IMF=0.885246;DP=61;VDB=7.33028e-19;SGB=-0.693147;MQSB=0.9725;MQ0F=0;AC=2;AN=2;DP4=0,0,23,31;MQ=57\tGT:PL\t1/1:255,163,0"
+    )
+    allele_combination_cov = {"1": 0, "2": 0}
+    allele_groups_dict = {"1": {0}}
+    allele_per_base_cov = [[0], [0], [0, 0]]
+    expected = vcf_record.VcfRecord(
+        "ref\t4\t.\tT\tG,TC\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t./.:0:0:0,0,0:.:0.0"
+    )
+    mean_depth = 85
+    error_rate = 0.001
+    depth_variance = 200
+    gtyper = genotyper.Genotyper(
+        mean_depth, depth_variance, error_rate, call_hets=False,
+    )
+    got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
+        record,
+        gtyper,
+        allele_combination_cov,
+        allele_per_base_cov,
+        allele_groups_dict,
+    )
+    assert record == expected
+    assert got_filtered == expected
 
-    def test_update_vcf_record_using_gramtools_allele_depths_homozygous(self):
-        """test update_using_gramtools_allele_depths homozygous"""
-        record = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tTC,G\t228\t.\tINDEL;IDV=54;IMF=0.885246;DP=61;VDB=7.33028e-19;SGB=-0.693147;MQSB=0.9725;MQ0F=0;AC=2;AN=2;DP4=0,0,23,31;MQ=57\tGT:PL\t1/1:255,163,0"
+def test_write_vcf_annotated_using_coverage_from_gramtools():
+    """test write_vcf_annotated_using_coverage_from_gramtools"""
+    vcf_file_in = os.path.join(
+        data_dir, "write_vcf_annotated_using_coverage_from_gramtools.in.vcf"
+    )
+    quasimap_dir = os.path.join(
+        data_dir, "write_vcf_annotated_using_coverage_from_gramtools.quasimap"
+    )
+    mean_depth, depth_variance, vcf_header, vcf_records, allele_coverage, allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
+        vcf_file_in, quasimap_dir
+    )
+    tmp_outfile = (
+        "tmp.gramtools.write_vcf_annotated_using_coverage_from_gramtools.vcf"
+    )
+    tmp_outfile_filtered = tmp_outfile + ".filter.vcf"
+    error_rate = 0.001
+    gramtools.write_vcf_annotated_using_coverage_from_gramtools(
+        mean_depth,
+        depth_variance,
+        vcf_records,
+        allele_coverage,
+        allele_groups,
+        error_rate,
+        tmp_outfile,
+        sample_name="sample_42",
+        max_read_length=200,
+        filtered_outfile=tmp_outfile_filtered,
+        ref_seq_lengths={"ref": "10000"},
+        call_hets=True,
+    )
+    expected_vcf = os.path.join(
+        data_dir, "write_vcf_annotated_using_coverage_from_gramtools.out.vcf"
+    )
+    expected_vcf_filtered = os.path.join(
+        data_dir,
+        "write_vcf_annotated_using_coverage_from_gramtools.out.vcf.filter.vcf",
+    )
+    # Today's date and the verison of minos get added to the header.
+    # We'll have to take account
+    # of those by fixing what we get from the expected file
+    def check_vcfs(expected_vcf, got_vcf):
+        expected_header, expected_vcf_records = vcf_file_read.vcf_file_to_list(
+            expected_vcf
         )
-        allele_combination_cov = {"1": 1, "2": 80}
-        allele_groups_dict = {"1": {0}, "2": {2}, "3": {1, 2}}
-        allele_per_base_cov = [[1], [0, 0], [80]]
-        expected = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tTC,G\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t2/2:81:0.9529:1,0,80:0.9877:87.29"
-        )
-        mean_depth = 85
-        error_rate = 0.001
-        got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
-            record,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-            mean_depth,
-            error_rate,
-        )
-        self.assertEqual(expected, record)
-        expected_filtered = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t1/1:81:0.9529:1,80:0.9877:87.29"
-        )
-        self.assertEqual(expected_filtered, got_filtered)
+        got_header, got_vcf_records = vcf_file_read.vcf_file_to_list(got_vcf)
+        for i in range(len(expected_header)):
+            if expected_header[i].startswith("##fileDate="):
+                expected_header[i] = "##fileDate=" + str(datetime.date.today())
+            elif expected_header[i].startswith("##source=minos"):
+                expected_header[i] = "##source=minos, version " + minos_version
 
-    def test_update_vcf_record_using_gramtools_allele_depths_not_callable(self):
-        """test update_using_gramtools_allele_depths not callable"""
-        record = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG,TC\t228\t.\tINDEL;IDV=54;IMF=0.885246;DP=61;VDB=7.33028e-19;SGB=-0.693147;MQSB=0.9725;MQ0F=0;AC=2;AN=2;DP4=0,0,23,31;MQ=57\tGT:PL\t1/1:255,163,0"
-        )
-        allele_combination_cov = {"1": 0, "2": 0}
-        allele_groups_dict = {"1": {0}}
-        allele_per_base_cov = [[0], [0], [0, 0]]
-        expected = vcf_record.VcfRecord(
-            "ref\t4\t.\tT\tG,TC\t.\t.\t.\tGT:DP:DPF:COV:FRS:GT_CONF\t./.:0:0:0,0,0:.:0.0"
-        )
-        mean_depth = 85
-        error_rate = 0.001
-        got_filtered = gramtools.update_vcf_record_using_gramtools_allele_depths(
-            record,
-            allele_combination_cov,
-            allele_per_base_cov,
-            allele_groups_dict,
-            mean_depth,
-            error_rate,
-        )
-        self.assertEqual(expected, record)
-        self.assertEqual(expected, got_filtered)
+        assert got_header == expected_header
+        assert got_vcf_records == expected_vcf_records
 
-    def test_write_vcf_annotated_using_coverage_from_gramtools(self):
-        """test write_vcf_annotated_using_coverage_from_gramtools"""
-        vcf_file_in = os.path.join(
-            data_dir, "write_vcf_annotated_using_coverage_from_gramtools.in.vcf"
-        )
-        quasimap_dir = os.path.join(
-            data_dir, "write_vcf_annotated_using_coverage_from_gramtools.quasimap"
-        )
-        mean_depth, depth_variance, vcf_header, vcf_records, allele_coverage, allele_groups = gramtools.load_gramtools_vcf_and_allele_coverage_files(
-            vcf_file_in, quasimap_dir
-        )
-        tmp_outfile = (
-            "tmp.gramtools.write_vcf_annotated_using_coverage_from_gramtools.vcf"
-        )
-        tmp_outfile_filtered = tmp_outfile + ".filter.vcf"
-        error_rate = 0.001
-        gramtools.write_vcf_annotated_using_coverage_from_gramtools(
-            mean_depth,
-            vcf_records,
-            allele_coverage,
-            allele_groups,
-            error_rate,
-            tmp_outfile,
-            sample_name="sample_42",
-            max_read_length=200,
-            filtered_outfile=tmp_outfile_filtered,
-            ref_seq_lengths={"ref": "10000"},
-        )
-        expected_vcf = os.path.join(
-            data_dir, "write_vcf_annotated_using_coverage_from_gramtools.out.vcf"
-        )
-        expected_vcf_filtered = os.path.join(
-            data_dir,
-            "write_vcf_annotated_using_coverage_from_gramtools.out.vcf.filter.vcf",
-        )
-        # Today's date and the verison of minos get added to the header.
-        # We'll have to take account
-        # of those by fixing what we get from the expected file
-        def check_vcfs(expected_vcf, got_vcf):
-            expected_header, expected_vcf_records = vcf_file_read.vcf_file_to_list(
-                expected_vcf
-            )
-            got_header, got_vcf_records = vcf_file_read.vcf_file_to_list(got_vcf)
-            for i in range(len(expected_header)):
-                if expected_header[i].startswith("##fileDate="):
-                    expected_header[i] = "##fileDate=" + str(datetime.date.today())
-                elif expected_header[i].startswith("##source=minos"):
-                    expected_header[i] = "##source=minos, version " + minos_version
+    check_vcfs(expected_vcf, tmp_outfile)
+    check_vcfs(expected_vcf_filtered, tmp_outfile_filtered)
+    os.unlink(tmp_outfile)
+    os.unlink(tmp_outfile_filtered)
 
-            self.assertEqual(expected_header, got_header)
-            self.assertEqual(expected_vcf_records, got_vcf_records)
+def test_load_allele_files():
+    """test load_allele_files"""
+    expected_counts_list = [
+        ({"0": 10, "1": 3, "2": 9}, [[1, 1, 1], [1, 1, 0]]),
+        ({"0": 30, "3": 2, "4": 1}, [[0, 0, 1], [2, 2, 0], [2, 2, 0, 1, 3]]),
+    ]
 
-        check_vcfs(expected_vcf, tmp_outfile)
-        check_vcfs(expected_vcf_filtered, tmp_outfile_filtered)
-        os.unlink(tmp_outfile)
-        os.unlink(tmp_outfile_filtered)
+    expected_groups_dict = {"0": {0}, "1": {1}, "2": {0, 1}, "3": {2}, "4": {1, 2}}
 
-    def test_load_allele_files(self):
-        """test load_allele_files"""
-        expected_counts_list = [
-            ({"0": 10, "1": 3, "2": 9}, [[1, 1, 1], [1, 1, 0]]),
-            ({"0": 30, "3": 2, "4": 1}, [[0, 0, 1], [2, 2, 0], [2, 2, 0, 1, 3]]),
-        ]
-
-        expected_groups_dict = {"0": {0}, "1": {1}, "2": {0, 1}, "3": {2}, "4": {1, 2}}
-
-        allele_base_counts_file = os.path.join(
-            data_dir, "load_allele_files.allele_base_counts.json"
-        )
-        grouped_allele_counts_file = os.path.join(
-            data_dir, "load_allele_files.grouped_allele_counts.json"
-        )
-        got_counts_list, got_groups_dict = gramtools.load_allele_files(
-            allele_base_counts_file, grouped_allele_counts_file
-        )
-        self.assertEqual(expected_counts_list, got_counts_list)
-        self.assertEqual(expected_groups_dict, got_groups_dict)
+    allele_base_counts_file = os.path.join(
+        data_dir, "load_allele_files.allele_base_counts.json"
+    )
+    grouped_allele_counts_file = os.path.join(
+        data_dir, "load_allele_files.grouped_allele_counts.json"
+    )
+    got_counts_list, got_groups_dict = gramtools.load_allele_files(
+        allele_base_counts_file, grouped_allele_counts_file
+    )
+    assert got_counts_list == expected_counts_list
+    assert got_groups_dict == expected_groups_dict


### PR DESCRIPTION
* Fixes bug where simulations to determine GCP distribution were always using het genotyping model, even if the run is only using hom model.
* bug fix meant that GCP shifted a little. Consequently, change default MIN_GCP filter from 5% to 2.5%.
* Change default MIN_DP filter from 0 to 2.
* Use negative binomial distribution for everything, instead of poisson. Fall back on poisson if coverage is too low.