### PR TITLE
Fixed #112. Added libjpeg-dev to dependencies

### DIFF
--- a/.ci/install_dependencies.sh
+++ b/.ci/install_dependencies.sh
@@ -20,6 +20,7 @@ apt-get install -y \
   libbz2-dev \
   libhts-dev \
   libssl-dev \
+  libjpeg-dev \
   pkg-config \
   python-dev \
   python3 \


### PR DESCRIPTION
When building the singularity image, pillow complains about missing jpeg
support. Adding the package libjepg-dev fixed #112 and the image is
built.