### PR TITLE
Update gramtools

### DIFF
--- a/.ci/install_dependencies.sh
+++ b/.ci/install_dependencies.sh
@@ -71,7 +71,7 @@ pip3 install tox "six>=1.14.0"
 cd $install_root
 git clone https://github.com/iqbal-lab-org/gramtools
 cd gramtools
-git checkout ee98085fbb9d8be5afd2288424c3d6dded796ab8
+git checkout 04c4ba717399507b643fd4b77a61c048ef2ed83f
 # Note: a simple "pip3 install ." works for singularity but
 # not for docker - the `gram` exectuable does not get
 # put where gramtools expects to find it. The method

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Dependencies:
 
 * Python 3 (tested on version 3.6.9)
 * [gramtools](https://github.com/iqbal-lab-org/gramtools) commit
-  ee98085fbb9d8be5afd2288424c3d6dded796ab8
+  04c4ba717399507b643fd4b77a61c048ef2ed83f
 * [bcftools](https://samtools.github.io/bcftools/)
 * [vt](https://github.com/atks/vt.git)
 * [vcflib](https://github.com/vcflib/vcflib.git). Specifically,


### PR DESCRIPTION
Update gramtools to 04c4ba717399507b643fd4b77a61c048ef2ed83f, which uses htslib 1.16.

See https://github.com/iqbal-lab-org/minos/issues/119